### PR TITLE
don't copy symbolic links to directories recursively

### DIFF
--- a/os/src/FileOps.scala
+++ b/os/src/FileOps.scala
@@ -174,7 +174,7 @@ object copy {
     }
 
     copyOne(from)
-    if (stat(from).isDir) walk(from).map(copyOne)
+    if (stat(from,followLinks=followLinks).isDir) walk(from).map(copyOne)
   }
 
   /**


### PR DESCRIPTION
Imagine a scenario in which "a" is a directory, "b" is a symbolic link to "a", and someone calls:

    os.copy(from=os.pwd / "b", to= os.pwd / "c", followLinks=false)

This will create a new symbolic link "c -> a" but then proceed to copy  the contents of "a" into "c" recursively. This is wrong because:

(1) there is no need to traverse the directory structure if we're just copying a symbolic link
(2) will end up copying files over themselves (changing mtime, raising atomicity concerns, ...)
(3) will fail if the link is dangling even though it should be acceptable to copy a dangling link
(4) will fail in unpredictable ways if we're copying to a different directory and the link is relative

This is caused by this line in os.copy.apply:

    if (stat(from).isDir) walk(from).map(copyOne)

Notice that it ignores "followLinks" and uses the default from "stat" which is true.

The fix is simple: pass "followLinks" to "stat".