### PR TITLE
os.copy honors the followLinks flag when copying symbolic links to dirs

### DIFF
--- a/os/src/FileOps.scala
+++ b/os/src/FileOps.scala
@@ -174,7 +174,7 @@ object copy {
     }
 
     copyOne(from)
-    if (stat(from).isDir) walk(from).map(copyOne)
+    if (stat(from, followLinks = followLinks).isDir) walk(from).map(copyOne)
   }
 
   /**


### PR DESCRIPTION
The way things stand, copying a symbolic link to a directory when 'followLinks=false' behave inconsistently:

(1) it copies the symbolic link as a symbolic link
(2) it traverses the directory structure attempting to recursively copy its contents

This is wrong for 2 reasons:

(1) The unnecessary cost of traversing the directory structure if you're just copying a link
(2) In some scenarios (see one below), the implementation will accidentally try to copy a file over itself

### A failure scenario

Imagine the following scenario:


      src (dir)
            t0 (dir)
                  f (file)
            t1 (symlink to t0)
            <<other files and directories>>


You want to copy the 't0' and 't1' into a different directory 'dest'? We can do something like:

```
    val dest = os.makeDir(...)
    os.copy(src/"t0", dest/"t0", followLinks=false, replaceExisting=false)
    os.copy(src/"t1", dest/"t1", followLinks=false, replaceExisting=false)
```

This will fail with:

```
java.nio.file.FileAlreadyExistsException: .../t1/file
	at java.base/sun.nio.fs.UnixCopyFile.copy(UnixCopyFile.java:571)
	at java.base/sun.nio.fs.UnixFileSystemProvider.copy(UnixFileSystemProvider.java:257)
	at java.base/java.nio.file.Files.copy(Files.java:1299)
	at os.copy$.copyOne$1(FileOps.scala:173)
	at os.copy$.$anonfun$apply$3(FileOps.scala:177)
```

Why?

- Copying src/t0 to dest/t0 recursively will work correctly
- Copying src/t1 to dest/t1 will also work but then attempting to recursively copy the contents of src/t1 will try to copy src/t0/file over the already copied dest/t0/file, causing the exception above.

We can hide the problem by setting 'replaceExisting=true' but that would be wrong (copies everything twice, unnecessary traversal, ...)

The fix is simple: pass "followLinks" to "stat".