### PR TITLE
[Please don't merge, working on a better solution] os.watch generates delete events for missing directories

### DIFF
--- a/os/watch/src/WatchServiceWatcher.scala
+++ b/os/watch/src/WatchServiceWatcher.scala
@@ -98,6 +98,10 @@ class WatchServiceWatcher(roots: Seq[os.Path],
         for(p <- currentlyWatchedPaths.keySet if !os.isDir(p, followLinks = false)){
           logger("WATCH CANCEL", p)
           currentlyWatchedPaths.remove(p).foreach(_.cancel())
+          
+          // We used to have this directory but now it's either
+          // gone or is not a directory. Report the change.
+          bufferedEvents.add(p)
         }
 
         recursiveWatches()

--- a/os/watch/test/src/WatchTests.scala
+++ b/os/watch/test/src/WatchTests.scala
@@ -49,7 +49,7 @@ object WatchTests extends TestSuite{
         action
         Thread.sleep(200)
         val changedSubPaths = changedPaths.map(_.subRelativeTo(wd))
-        assert(expectedChangedPaths == changedSubPaths)
+        assert(expectedChangedPaths.subsetOf(changedSubPaths))
       }
 
       checkFileManglingChanges(wd / "test")

--- a/readme.md
+++ b/readme.md
@@ -1629,7 +1629,7 @@ an event containing the path for:
   every file or folder within it.
 
 - For deleted or moved folders, the root folder which was deleted/moved,
-  but *without* the paths of every file that was within it at the
+  but *not necessarily* the paths of every file that was within it at the
   original location
 
 Note that `watch` does not provide any additional information about the


### PR DESCRIPTION
Problem: under stress, `WatchService` drops some directory `DELETE` events

Impact: implementations of `os.watch.watch` that rely on `WatchService` will not report those events

Solution: `os.watch.watch` keeps track of all watched directories in `currentWatchedPaths` and refreshes this list after each event anyway. Report `DELETE` events for missing directories that used to exist.

Implication: folder moves will generate `DELETE` events for subdirectories.

Is this a problem? depends on how you interpret the documentation but the existing implementation is doing the same for directory deletes.

Remedy: changed the wording from "without" to "not necessarily". This also makes it necessary to change the `os.watch` test cases to check for subset instead of strict equality.

Potential problem: might surprise existing code.