### PR TITLE
Error reporting mechanism for os.watch

### DIFF
--- a/os/watch/src/ErrorResponse.scala
+++ b/os/watch/src/ErrorResponse.scala
@@ -1,0 +1,18 @@
+package os.watch
+
+// How to react to service errors
+sealed trait ErrorResponse
+
+object ErrorResponse {
+  // close this instnace of the watch service
+  case object Close extends ErrorResponse
+  
+  // Other possibilities
+  //case object Continue extends ErrorResponse // the caller fixed the state
+  //case class Restart(paths: Seq[os.Path]) extends ErrorResponse // the caller knows
+
+  def defaultHandler(e: WatchError): ErrorResponse = {
+    println(e)
+    Close
+  }
+}

--- a/os/watch/src/WatchError.scala
+++ b/os/watch/src/WatchError.scala
@@ -1,0 +1,6 @@
+package os.watch
+
+sealed trait WatchError
+
+case object Overflow extends WatchError
+case class InternalError(t: Throwable) extends WatchError

--- a/os/watch/src/package.scala
+++ b/os/watch/src/package.scala
@@ -1,6 +1,7 @@
 package os
 
 package object watch{
+  
   /**
     * Efficiently watches the given `roots` folders for changes. Any time the
     * filesystem is modified within those folders, the `onEvent` callback is
@@ -29,9 +30,11 @@ package object watch{
     */
   def watch(roots: Seq[os.Path],
             onEvent: Set[os.Path] => Unit,
-            logger: (String, Any) => Unit = (_, _) => ()): AutoCloseable  = {
+            logger: (String, Any) => Unit = (_, _) => (),
+            onError: WatchError => ErrorResponse = ErrorResponse.defaultHandler
+           ): AutoCloseable  = {
     val watcher = System.getProperty("os.name") match{
-      case "Linux" => new os.watch.WatchServiceWatcher(roots, onEvent, logger)
+      case "Linux" => new os.watch.WatchServiceWatcher(roots, onEvent, logger, onError)
       case "Mac OS X" => new os.watch.FSEventsWatcher(roots, onEvent, logger, 0.05)
       case osName => throw new Exception(s"watch not supported on operating system: $osName")
     }

--- a/readme.md
+++ b/readme.md
@@ -1603,7 +1603,10 @@ sha.stdout.trim ==> "acc142175fa520a1cb2be5b97cbbe9bea092e8bba3fe2e95afa64561590
 #### os.watch.watch
 
 ```scala
-os.watch.watch(roots: Seq[os.Path], onEvent: Set[os.Path] => Unit): Unit
+os.watch.watch(roots: Seq[os.Path],
+  onEvent: Set[os.Path] => Unit,
+  onError: os.watch.WatchError => os.watch.ErrorResponse = os.watch.ErrorResponse.defaultHandler
+): Unit
 ```
 ```scala
 // SBT
@@ -1636,6 +1639,20 @@ Note that `watch` does not provide any additional information about the
 changes happening within the watched roots folder, apart from the path
 at which the change happened. It is up to the `onEvent` handler to query
 the filesystem and figure out what happened, and what it wants to do.
+
+Possible errors (passed to the `onError` callback)
+
+- `WatchError.Overflow` The system is producing events faster
+  than the application is able to handle them.
+  
+- `WatchError.InternalError(e: Throwable)` For example: removing a drive
+  with watched paths.
+  
+Error responses:
+
+- `ErrorResponse.Close`. Terminate this instance of the watch service
+
+The default error handler prints an error message and returns `ErrorResponse.Close`
 
 Here is an example of use from the Ammonite REPL:
 


### PR DESCRIPTION
`os.watch.watch` has 2 distinct phases: (1) recursively scan the watched paths, (2) fork a thread that listens for notifications and reports them back by calling on `onEvent` function.

Some (but not all) of the errors occurring caught during the second phase print a stack trace and terminate the watcher without informing the caller.

Source of errors:

- `overflow`: the underlying watch mechanism usually has an in-kernel buffer that might overflow. Both `Linux` and `OSX` report those back as `overflow` events indicating loss of information.
- Resource limits: too many open files, etc.
- Yanking an external drive
- Changing permissions
- ...

My use case for `os.watch` restarts itself every 5 minutes to compensate for lack of reliable error reporting

The proposed API changes (should be backwards compatible with existing code)

- Add a 3rd callback to `os.watch.watch`( `onError: WatchError => ErrorResult`)
- Add a sealed trait for different kinds of errors (`WatchError`)
- Add a sealed trait for error responses (`ErrorResult`)
- Add a default error handler (`defaultHandler`) that behaves like the current implementation

Issues:

- Ordering between events and errors is harder to establish then if the same callback handled both. Doing this would change the API in a non-backwards compatible way