### PR TITLE
Restore binary compatible copy methods

### DIFF
--- a/os/src/FileOps.scala
+++ b/os/src/FileOps.scala
@@ -193,15 +193,24 @@ object copy {
   }
 
   /** This overload is only to keep binary compatibility with older os-lib versions.  */
-  @deprecated("Use os.copy(from, to, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders) instead", "os-lib 0.7.5")
+  @deprecated("Use os.copy(from, to, followLinks, replaceExisting, copyAttributes, " +
+    "createFolders, mergeFolders) instead", "os-lib 0.7.5")
   def apply(
-             from: Path,
-             to: Path,
-             followLinks: Boolean,
-             replaceExisting: Boolean,
-             copyAttributes: Boolean,
-             createFolders: Boolean
-           ): Unit = apply(from, to, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders = false)
+    from: Path,
+    to: Path,
+    followLinks: Boolean,
+    replaceExisting: Boolean,
+    copyAttributes: Boolean,
+    createFolders: Boolean
+  ): Unit = apply(
+    from = from,
+    to = to,
+    followLinks = followLinks,
+    replaceExisting = replaceExisting,
+    copyAttributes = copyAttributes,
+    createFolders = createFolders,
+    mergeFolders = false
+  )
 
   /**
     * Copy a file into a particular folder, rather
@@ -222,7 +231,8 @@ object copy {
     }
 
     /** This overload is only to keep binary compatibility with older os-lib versions.  */
-    @deprecated("Use os.copy.into(from, to, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders) instead", "os-lib 0.7.5")
+    @deprecated("Use os.copy.into(from, to, followLinks, replaceExisting, copyAttributes, " +
+      "createFolders, mergeFolders) instead", "os-lib 0.7.5")
     def apply(
       from: Path,
       to: Path,
@@ -230,7 +240,15 @@ object copy {
       replaceExisting: Boolean,
       copyAttributes: Boolean,
       createFolders: Boolean
-    ): Unit = apply(from, to, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders = false)
+    ): Unit = apply(
+      from = from,
+      to = to,
+      followLinks = followLinks,
+      replaceExisting = replaceExisting,
+      copyAttributes = copyAttributes,
+      createFolders = createFolders,
+      mergeFolders = false
+    )
   }
 
   /**

--- a/os/src/FileOps.scala
+++ b/os/src/FileOps.scala
@@ -153,6 +153,28 @@ object copy {
   def matching(partialFunction: PartialFunction[Path, Path]): PartialFunction[Path, Unit] = {
     matching()(partialFunction)
   }
+
+  /** This overload is only to keep binary compatibility with older os-lib versions.  */
+  @deprecated("Use os.copy(from, to, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders) instead", "os-lib 0.7.5")
+  def apply(
+    from: Path,
+    to: Path,
+    followLinks: Boolean,
+    replaceExisting: Boolean,
+    copyAttributes: Boolean,
+    createFolders: Boolean
+  ): Unit = {
+    apply(
+      from = from,
+      to = to,
+      followLinks,
+      replaceExisting,
+      copyAttributes,
+      createFolders,
+      mergeFolders = false
+    )
+  }
+
   def apply(
              from: Path,
              to: Path,

--- a/os/src/FileOps.scala
+++ b/os/src/FileOps.scala
@@ -263,7 +263,15 @@ object copy {
               copyAttributes: Boolean = false,
               createFolders: Boolean = false): Unit = {
       os.remove.all(to)
-      os.copy(from, to, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders = false)
+      os.copy(
+        from = from,
+        to = to,
+        followLinks = followLinks,
+        replaceExisting = replaceExisting,
+        copyAttributes = copyAttributes,
+        createFolders = createFolders,
+        mergeFolders = false
+      )
     }
   }
 }

--- a/os/src/FileOps.scala
+++ b/os/src/FileOps.scala
@@ -154,27 +154,6 @@ object copy {
     matching()(partialFunction)
   }
 
-  /** This overload is only to keep binary compatibility with older os-lib versions.  */
-  @deprecated("Use os.copy(from, to, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders) instead", "os-lib 0.7.5")
-  def apply(
-    from: Path,
-    to: Path,
-    followLinks: Boolean,
-    replaceExisting: Boolean,
-    copyAttributes: Boolean,
-    createFolders: Boolean
-  ): Unit = {
-    apply(
-      from = from,
-      to = to,
-      followLinks,
-      replaceExisting,
-      copyAttributes,
-      createFolders,
-      mergeFolders = false
-    )
-  }
-
   def apply(
              from: Path,
              to: Path,
@@ -213,6 +192,17 @@ object copy {
     if (stat(from, followLinks = followLinks).isDir) walk(from).map(copyOne)
   }
 
+  /** This overload is only to keep binary compatibility with older os-lib versions.  */
+  @deprecated("Use os.copy(from, to, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders) instead", "os-lib 0.7.5")
+  def apply(
+             from: Path,
+             to: Path,
+             followLinks: Boolean,
+             replaceExisting: Boolean,
+             copyAttributes: Boolean,
+             createFolders: Boolean
+           ): Unit = apply(from, to, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders = false)
+
   /**
     * Copy a file into a particular folder, rather
     * than into a particular path
@@ -230,6 +220,17 @@ object copy {
         followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders
       )
     }
+
+    /** This overload is only to keep binary compatibility with older os-lib versions.  */
+    @deprecated("Use os.copy.into(from, to, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders) instead", "os-lib 0.7.5")
+    def apply(
+      from: Path,
+      to: Path,
+      followLinks: Boolean,
+      replaceExisting: Boolean,
+      copyAttributes: Boolean,
+      createFolders: Boolean
+    ): Unit = apply(from, to, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders = false)
   }
 
   /**
@@ -244,7 +245,7 @@ object copy {
               copyAttributes: Boolean = false,
               createFolders: Boolean = false): Unit = {
       os.remove.all(to)
-      os.copy(from, to, followLinks, replaceExisting, copyAttributes, createFolders)
+      os.copy(from, to, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders = false)
     }
   }
 }


### PR DESCRIPTION
The binary incompatibilities where introduces with pull request #65 and release with os-lib `0.7.5`.

Fix https://github.com/com-lihaoyi/os-lib/issues/77