### PR TITLE
Don't fail `os.remove(file)` when the file doesn't exist

### DIFF
--- a/os/src/FileOps.scala
+++ b/os/src/FileOps.scala
@@ -281,7 +281,7 @@ object copy {
  * does nothing if there aren't any
  */
 object remove extends Function1[Path, Unit]{
-  def apply(target: Path): Unit = Files.delete(target.wrapped)
+  def apply(target: Path): Unit = Files.deleteIfExists(target.wrapped)
 
   object all extends Function1[Path, Unit]{
     def apply(target: Path) = {


### PR DESCRIPTION
This is what the docs say, and what `os.remove.all` does, but with a single file it may throw `FileNotFoundException`