### PR TITLE
Make .ext on empty paths return "" rather than crashing with a NPE

### DIFF
--- a/os/src-jvm/ResourcePath.scala
+++ b/os/src-jvm/ResourcePath.scala
@@ -23,7 +23,7 @@ class ResourcePath private[os](val resRoot: ResourceRoot, segments0: Array[Strin
   def toSource = new Source.WritableSource(getInputStream)
   val segments: IndexedSeq[String] = segments0
   type ThisType = ResourcePath
-  def last = segments0.last
+  def lastOpt = segments0.lastOption
   override def toString = resRoot.errorName + "/" + segments0.mkString("/")
   protected[this] def make(p: Seq[String], ups: Int) = {
     if (ups > 0){

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -198,7 +198,7 @@ trait BasePathImpl extends BasePath{
     else last.slice(0, li)
   }
 
-  def last: String = lastOpt.getOrElse("empty path has no last segment")
+  def last: String = lastOpt.getOrElse(throw PathError.LastOnEmptyPath())
 
   def lastOpt: Option[String]
 }
@@ -215,6 +215,9 @@ object PathError{
 
   case class NoRelativePath(src: RelPath, base: RelPath)
     extends IAE(s"Can't relativize relative paths $src from $base")
+
+  case class LastOnEmptyPath()
+    extends IAE("empty path has no last segment")
 }
 
 /**

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -47,6 +47,13 @@ object PathTests extends TestSuite{
           assert((base / "baseOnly").ext == "")
           assert((base / "baseOnly.").ext == "")
         }
+
+        test("emptyExt"){
+          os.root.ext ==> ""
+          os.rel.ext ==> ""
+          os.sub.ext ==> ""
+          os.up.ext ==> ""
+        }
       }
 
       test("RelPath"){

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -54,6 +54,17 @@ object PathTests extends TestSuite{
           os.sub.ext ==> ""
           os.up.ext ==> ""
         }
+
+        test("emptyLast"){
+          intercept[PathError.LastOnEmptyPath](os.root.last).getMessage ==>
+            "empty path has no last segment"
+          intercept[PathError.LastOnEmptyPath](os.rel.last).getMessage ==>
+            "empty path has no last segment"
+          intercept[PathError.LastOnEmptyPath](os.sub.last).getMessage ==>
+            "empty path has no last segment"
+          intercept[PathError.LastOnEmptyPath](os.up.last).getMessage ==>
+            "empty path has no last segment"
+        }
       }
 
       test("RelPath"){


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/Ammonite/issues/1017

This is more consistent with calling `.ext` on non-empty paths which have no extension, since those currently return `""`

We also introduce a new a `lastOption`  method, as a way to get the last segment in a list without throwing. Not sure if that's the right thing to do, or whether we should make `.last` return `""` (which is otherwise not a valid return value, since path segments cannot be empty).

Covered with simple unit tests