### PR TITLE
Avoid throwing an exception when sorting identical paths

### DIFF
--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -409,16 +409,20 @@ object Path {
         var xSeg = ""
         var ySeg = ""
         var i = 0
+        var result: Integer = null
         while ({
           xSeg = x.getSegment(i)
           ySeg = y.getSegment(i)
           i += 1
           val compared = Ordering.String.compare(xSeg, ySeg)
           if (i < xSegCount && compared == 0) true // continue
-          else return compared
+          else {
+            result = compared
+            false
+          }
         }) ()
 
-        ???
+        result
       }
     }
   }

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -414,11 +414,8 @@ object Path {
           ySeg = y.getSegment(i)
           i += 1
           val compared = Ordering.String.compare(xSeg, ySeg)
-          if (i == xSegCount) return compared
-          else compared match{
-            case 0 => true // continue
-            case n => return n
-          }
+          if (i < xSegCount && compared == 0) true // continue
+          else return compared
         }) ()
 
         ???

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -408,14 +408,14 @@ object Path {
       else{
         var xSeg = ""
         var ySeg = ""
-        var i = -1
+        var i = 0
         while ({
-          i += 1
           xSeg = x.getSegment(i)
           ySeg = y.getSegment(i)
+          i += 1
           i < xSegCount && xSeg == ySeg
         }) ()
-        if (i == xSegCount) 0
+        if (i == xSegCount - 1) 0
         else Ordering.String.compare(xSeg, ySeg)
       }
     }

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -415,8 +415,8 @@ object Path {
           i += 1
           i < xSegCount && xSeg == ySeg
         }) ()
-        if (i == xSegCount + 1) 0
-        else Ordering.String.compare(xSeg, ySeg)
+
+        Ordering.String.compare(xSeg, ySeg)
       }
     }
   }

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -415,7 +415,7 @@ object Path {
           i += 1
           i < xSegCount && xSeg == ySeg
         }) ()
-        if (i == xSegCount - 1) 0
+        if (i == xSegCount + 1) 0
         else Ordering.String.compare(xSeg, ySeg)
       }
     }

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -413,10 +413,15 @@ object Path {
           xSeg = x.getSegment(i)
           ySeg = y.getSegment(i)
           i += 1
-          i < xSegCount && xSeg == ySeg
+          val compared = Ordering.String.compare(xSeg, ySeg)
+          if (i == xSegCount) return compared
+          else compared match{
+            case 0 => true // continue
+            case n => return n
+          }
         }) ()
 
-        Ordering.String.compare(xSeg, ySeg)
+        ???
       }
     }
   }

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -328,11 +328,10 @@ object PathTests extends TestSuite{
     }
     test("sorting"){
       test - {
-        os.Path.pathOrdering.compare(root / "a", root / "b")
-//        assert(
-//          Seq(root/"c", root, root/"b", root/"a").sorted ==
-//            Seq(root, root/"a", root/"b", root/"c")
-//        )
+        assert(
+          Seq(root/"c", root, root/"b", root/"a").sorted ==
+          Seq(root, root/"a", root/"b", root/"c")
+        )
       }
 
       test - assert(

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -327,10 +327,19 @@ object PathTests extends TestSuite{
       }
     }
     test("sorting"){
-      assert(
-        Seq(root/"c", root, root/"b", root/"a").sorted == Seq(root, root/"a", root/"b", root/"c"),
+      test - assert(
+        Seq(root/"c", root, root/"b", root/"a").sorted ==
+        Seq(root, root/"a", root/"b", root/"c")
+      )
+
+      test - assert(
         Seq(up/"c", up/up/"c", rel/"b"/"c", rel/"a"/"c", rel/"a"/"d").sorted ==
-          Seq(rel/"a"/"c", rel/"a"/"d", rel/"b"/"c", up/"c", up/up/"c")
+        Seq(rel/"a"/"c", rel/"a"/"d", rel/"b"/"c", up/"c", up/up/"c")
+      )
+
+      test - assert(
+        Seq(os.root / "yo", os.root / "yo").sorted ==
+        Seq(os.root / "yo", os.root / "yo")
       )
     }
     test("construction"){

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -327,10 +327,13 @@ object PathTests extends TestSuite{
       }
     }
     test("sorting"){
-      test - assert(
-        Seq(root/"c", root, root/"b", root/"a").sorted ==
-        Seq(root, root/"a", root/"b", root/"c")
-      )
+      test - {
+        os.Path.pathOrdering.compare(root / "a", root / "b")
+//        assert(
+//          Seq(root/"c", root, root/"b", root/"a").sorted ==
+//            Seq(root, root/"a", root/"b", root/"c")
+//        )
+      }
 
       test - assert(
         Seq(up/"c", up/up/"c", rel/"b"/"c", rel/"a"/"c", rel/"a"/"d").sorted ==


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/os-lib/issues/44

The basic issue is that our loops `i` is being incremented and fed into `getSegment` before the out-of-bounds check. Thus if two paths are identical, it ends up overshooting the end of the sequence of segments, resulting in the error reported. The fix is to order the `i += 1` such that it takes place immediately before the out-of-bounds check, to ensure it is always in bounds when we pass it to `getSegment`

The `i == xSegCount` check at the bottom was also incorrect. Just because we've hit the end of the list doesn't mean the two paths are equal, as the point of the loop is to find the first non-equal string segment so we can compare them. Thus we should compare the two string segments every time: if they are equal and we haven't run out, we loop another time, otherwise we return the result of the comparison

Adds a test case that reproduces the failure on master, passes on this PR

Review by @lefou 