### PR TITLE
Fix os.pwd: evalute every time and use portable approach

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -107,7 +107,8 @@ trait OsLibModule extends CrossScalaModule with PublishModule{
 trait OsLibTestModule extends ScalaModule with TestModule{
   def ivyDeps = Agg(
     ivy"com.lihaoyi::utest::0.7.10",
-    ivy"com.lihaoyi::sourcecode::0.2.7"
+    ivy"com.lihaoyi::sourcecode::0.2.7",
+    ivy"com.github.jnr:jnr-posix:3.1.14",
   )
 
   def platformSegment: String

--- a/os/src-jvm/package.scala
+++ b/os/src-jvm/package.scala
@@ -18,10 +18,16 @@ package object os{
    */
   val home: Path = Path(System.getProperty("user.home"))
 
+  private val initialWorkingDirectory: Path = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
+
+  private var cwdSupplier: () => Path = () => initialWorkingDirectory
+
+  def setCwdSupplier(supplier: () => Path) = { cwdSupplier = supplier }
+
   /**
    * The current working directory for this process.
    */
-  val pwd: Path = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
+  def pwd: Path = cwdSupplier()
 
   val up: RelPath = RelPath.up
 

--- a/os/src-native/package.scala
+++ b/os/src-native/package.scala
@@ -14,10 +14,16 @@ package object os{
    */
   val home: Path = Path(System.getProperty("user.home"))
 
+  private val initialWorkingDirectory: Path = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
+
+  private var cwdSupplier: () => Path = () => initialWorkingDirectory
+
+  def setCwdSupplier(supplier: () => Path) = { cwdSupplier = supplier }
+
   /**
    * The current working directory for this process.
    */
-  val pwd: Path = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
+  def pwd: Path = cwdSupplier()
 
   val up: RelPath = RelPath.up
 

--- a/os/test/src-jvm/WorkingDirectoryTests.scala
+++ b/os/test/src-jvm/WorkingDirectoryTests.scala
@@ -1,0 +1,26 @@
+package test.os
+
+import test.os.TestUtil.prep
+import utest._
+
+object WorkingDirectoryTests extends TestSuite {
+  def tests = Tests{
+    test("change"){
+      if(Unix()){
+        val posix = jnr.posix.POSIXFactory.getPOSIX()
+        os.setCwdSupplier(() => os.Path(posix.getcwd()))
+
+        val initialWd = os.pwd
+
+        val expectedWd = os.Path("/var/tmp/os-lib-wd-test")
+        os.makeDir.all(expectedWd)
+
+        val res = posix.chdir(expectedWd.toString)
+        assert(res == 0)
+
+        val finalWd = os.pwd
+        assert(expectedWd == finalWd)
+      }
+    }
+  }
+}


### PR DESCRIPTION
The current working directory of a process may change over time, hence
os.pwd must not be a value that is initialized once, but instead a
callable function.

Furthermore, I think the more portable approach to get the current
working directory is

Paths.get("").toAbsolutePath()

as "." appears to be Unix specific.