### PR TITLE
Add the actual command to CommandResult

### DIFF
--- a/os/src-jvm/ProcessOps.scala
+++ b/os/src-jvm/ProcessOps.scala
@@ -22,6 +22,8 @@ import scala.annotation.tailrec
   *   want
   */
 case class proc(command: Shellable*) {
+  val commandChunks = command.flatMap(_.value)
+
   /**
     * Invokes the given subprocess like a function, passing in input and returning a
     * [[CommandResult]]. You can then call `result.exitCode` to see how it exited, or
@@ -80,7 +82,7 @@ case class proc(command: Shellable*) {
     sub.join(timeout)
 
     val chunksArr = chunks.iterator.asScala.toArray
-    val res = CommandResult(sub.exitCode(), chunksArr)
+    val res = CommandResult(commandChunks, sub.exitCode(), chunksArr)
     if (res.exitCode == 0 || !check) res
     else throw SubprocessException(res)
   }
@@ -117,7 +119,6 @@ case class proc(command: Shellable*) {
 
     builder.directory(Option(cwd).getOrElse(os.pwd).toIO)
 
-    val commandChunks = command.flatMap(_.value)
     val commandStr = commandChunks.mkString(" ")
     lazy val proc: SubProcess = new SubProcess(
       builder

--- a/os/src-jvm/ProcessOps.scala
+++ b/os/src-jvm/ProcessOps.scala
@@ -22,7 +22,7 @@ import scala.annotation.tailrec
   *   want
   */
 case class proc(command: Shellable*) {
-  val commandChunks = command.flatMap(_.value)
+  def commandChunks: Seq[String] = command.flatMap(_.value)
 
   /**
     * Invokes the given subprocess like a function, passing in input and returning a
@@ -119,10 +119,11 @@ case class proc(command: Shellable*) {
 
     builder.directory(Option(cwd).getOrElse(os.pwd).toIO)
 
-    val commandStr = commandChunks.mkString(" ")
+    val cmdChunks = commandChunks
+    val commandStr = cmdChunks.mkString(" ")
     lazy val proc: SubProcess = new SubProcess(
       builder
-        .command(commandChunks:_*)
+        .command(cmdChunks:_*)
         .redirectInput(stdin.redirectFrom)
         .redirectOutput(stdout.redirectTo)
         .redirectError(stderr.redirectTo)

--- a/os/src/Model.scala
+++ b/os/src/Model.scala
@@ -168,7 +168,7 @@ case class PermSet(value: Int) {
   * wrapping stdout/stderr respectively, and providing convenient access to
   * the aggregate output of each stream, as bytes or strings or lines.
   */
-case class CommandResult(exitCode: Int,
+case class CommandResult(command: Seq[String], exitCode: Int,
                          chunks: Seq[Either[geny.Bytes, geny.Bytes]]) {
   /**
     * The standard output and error of the executed command, exposed in a
@@ -185,7 +185,8 @@ case class CommandResult(exitCode: Int,
   }
 
   override def toString() = {
-    s"CommandResult $exitCode\n" +
+    val denoteMoreCommandChunks = if (command.length == 1) "" else "…"
+    s"Result of ${command.head}${denoteMoreCommandChunks}: $exitCode\n" +
       chunks.iterator
         .collect{case Left(s) => s case Right(s) => s}
         .map(x => new String(x.array))

--- a/os/src/Model.scala
+++ b/os/src/Model.scala
@@ -168,7 +168,8 @@ case class PermSet(value: Int) {
   * wrapping stdout/stderr respectively, and providing convenient access to
   * the aggregate output of each stream, as bytes or strings or lines.
   */
-case class CommandResult(command: Seq[String], exitCode: Int,
+case class CommandResult(command: Seq[String],
+                         exitCode: Int,
                          chunks: Seq[Either[geny.Bytes, geny.Bytes]]) {
   /**
     * The standard output and error of the executed command, exposed in a


### PR DESCRIPTION
The messages of exceptions thrown by call() would previously just
mention the exit status of the invoked process, but not the actual
command line that was used to create the process. To help with
debugging purposes, the exception message now includes the full
command line and the os.proc instance provides access to it.