### PR TITLE
Add os.Path.of()

### DIFF
--- a/os/src-jvm/package.scala
+++ b/os/src-jvm/package.scala
@@ -21,7 +21,7 @@ package object os{
   /**
    * The current working directory for this process.
    */
-  val pwd: Path = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
+  val pwd: Path = os.Path.cwd
 
   val up: RelPath = RelPath.up
 

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -374,6 +374,17 @@ object Path {
     case p: Path => p
   }
 
+  private[os] val cwd = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
+
+  /**
+    * Converts absolute paths, relative paths and automatically
+    * expands leading `~/` into the user's home directory.
+    */
+  def of[T: PathConvertible](f: T, base: Path = null) =
+    // Note that we can't use os.pwd as it would cause a cyclic
+    // dependency. Hence the package-scoped os.Path.getPwd.
+    expandUser(f, if (base == null) cwd else base)
+
   /**
     * Equivalent to [[os.Path.apply]], but automatically expands a
     * leading `~/` into the user's home directory, for convenience


### PR DESCRIPTION
This is the second iteration after https://github.com/com-lihaoyi/os-lib/pull/88. I still feel like os-lib is lacking such a convenience method. Happy to add unit tests if you feel that this should go forward.

OS-Lib was lacking a convenience methods that lets user construct
absolute paths from a wide range of inputs values. In particular,
there is no function that takes either an absolute path, relative path
or a tilde prefixed path and constructs an absolute os.Path from it.

The newly added Path.of() is exactly such a function, plus it includes
the functionality of the already existing Path.expandUser() function.