### PR TITLE
Adjust os.Path.apply() to take relative paths and expand home

### DIFF
--- a/os/src-jvm/package.scala
+++ b/os/src-jvm/package.scala
@@ -23,7 +23,7 @@ package object os{
   /**
    * The current working directory for this process.
    */
-  val pwd: Path = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
+  val pwd: Path = os.Path.cwd
 
   val up: RelPath = RelPath.up
 

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -117,6 +117,10 @@ object PathTests extends TestSuite{
                 )
               }
             }
+            test("PathApplyWithRelativeArg"){
+              val pathWithRelativeArg = os.Path("foo/bar")
+              assert(pathWithRelativeArg == os.pwd / "foo" / "bar")
+            }
           }
         }
         test("Relativize"){
@@ -194,6 +198,7 @@ object PathTests extends TestSuite{
         val d = pwd
         val abs = d / base
         test("Constructor"){
+          println(s"${abs.toString.drop(d.toString.length)}; d: $d; abs: $abs;")
           if (Unix()) assert(
             abs.toString.drop(d.toString.length) == "/src/main/scala",
             abs.toString.length > d.toString.length
@@ -300,7 +305,6 @@ object PathTests extends TestSuite{
       }}
       test("InvalidCasts"){
         if(Unix()){
-          intercept[IllegalArgumentException](Path("omg/cow"))
           intercept[IllegalArgumentException](RelPath("/omg/cow"))
         }
       }
@@ -393,11 +397,6 @@ object PathTests extends TestSuite{
       }
       test("failure"){
         if(Unix()){
-          val relStr = "hello/.."
-          intercept[java.lang.IllegalArgumentException]{
-            Path(relStr)
-          }
-
           val absStr = "/hello"
           intercept[java.lang.IllegalArgumentException]{
             RelPath(absStr)


### PR DESCRIPTION
OS-Lib was lacking a convenience methods that lets user construct
absolute paths from a wide range of inputs values. In particular,
there is no function that takes either an absolute path, relative path
or a tilde prefixed path and constructs an absolute os.Path from
it.

The new behavior of os.Path.apply() accommodates for this.

Although I am not sure if I understand the proposal made in https://github.com/com-lihaoyi/os-lib/pull/101#issuecomment-1112731311, this hopefully satisfies the proposal.