### PR TITLE
Make Shellable a sequence of CharSequence(s)

### DIFF
--- a/os/src/Model.scala
+++ b/os/src/Model.scala
@@ -211,6 +211,7 @@ case class SubprocessException(result: CommandResult) extends Exception(result.t
 case class Shellable(value: Seq[String])
 object Shellable{
   implicit def StringShellable(s: String): Shellable = Shellable(Seq(s))
+  implicit def CharSequenceShellable(cs: CharSequence): Shellable = Shellable(Seq(cs.toString))
 
   implicit def SymbolShellable(s: Symbol): Shellable = Shellable(Seq(s.name))
   implicit def PathShellable(s: Path): Shellable = Shellable(Seq(s.toString))

--- a/os/test/src-jvm/SubprocessTests.scala
+++ b/os/test/src-jvm/SubprocessTests.scala
@@ -93,6 +93,16 @@ object SubprocessTests extends TestSuite{
       }
     }
 
+    test("charSequence"){
+      val charSequence = new StringBuilder("This is a CharSequence")
+      val cmd = Seq(
+        "echo",
+        charSequence
+      )
+      val res = proc(cmd).call()
+      assert(res.out.text().trim() == charSequence.toString())
+    }
+
     test("envArgs"){ if(Unix()){
       val res0 = proc("bash", "-c", "echo \"Hello$ENV_ARG\"").call(env = Map("ENV_ARG" -> "12"))
       assert(res0.out.lines() == Seq("Hello12"))


### PR DESCRIPTION
This allows to pass everythign that is a CharSequence to
os.proc(). Previously one had to add an extra toString() call, e.g.,:

    val host = org.minidns.dnsname.DnsName.from("example.org")
    os.proc("ping", host.toString).call()

now

    val host = org.minidns.dnsname.DnsName.from("example.org")
    os.proc("ping", host).call()