### PR TITLE
Enable support for MiMa checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,20 @@ jobs:
       - run: ./mill.bat -i -k __.jvm.__.test
         if: matrix.os == 'windows-latest'
 
+  check-bin-compat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 8
+
+      - run: ./mill -i -k __.mimaReportBinaryIssues
+
   publish-sonatype:
     if: github.repository == 'com-lihaoyi/os-lib' && contains(github.ref, 'refs/tags/')
     needs: test


### PR DESCRIPTION
Turns out, we already broke our binary API since 0.8.0 in two pull requests.

So, I will de-facto disable the checks as we have no version to which we want to stay compatible.
We can fill the list, once we make the next release.

Also added GHA CI action for MiMa checks.

Here are the PRs which broke bin compat:
* #100 
* #104 

I don't think we should revert them. 
To the contrary, both contain useful improvements.
Instead, we should try to improve the code base even more and probably make changes which break the API now.
After that we should create a test release 0.9, and when we find it good, also create 1.0 release.

* Implements #111 