### PR TITLE
Fix watcher test for OSX

### DIFF
--- a/os/watch/test/src/WatchTests.scala
+++ b/os/watch/test/src/WatchTests.scala
@@ -127,7 +127,7 @@ object WatchTests extends TestSuite with TestSuite.Retries {
           case "Linux" => Set(os.sub / "newlink3")
           case "Mac OS X" =>
             Set(
-              //os.sub / "newlink3",
+              os.sub / "newlink3",
               os.sub / "folder3" / "nestedA",
               os.sub / "folder3" / "nestedA" / "a.txt"
             )


### PR DESCRIPTION
For some reason a part of the watcher test for OSX which has been commented out before is working now.

Tested on OSX 15, Apple M1