### PR TITLE
Enable Scalafmt and format everything

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Format the codebase for the first time
+b049841d5707d5bd87be516d8cda7be2a7585eae

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,20 @@ jobs:
 
       - run: ./mill -i -k __.mimaReportBinaryIssues
 
+  check-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 8
+
+      - run: ./mill -i -k __.checkFormat
+
   publish-sonatype:
     if: github.repository == 'com-lihaoyi/os-lib' && contains(github.ref, 'refs/tags/')
     needs: test

--- a/build.sc
+++ b/build.sc
@@ -6,6 +6,7 @@ import $ivy.`com.github.lolgab::mill-mima::0.0.13`
 import mill._
 import mill.define.{Task, Target}
 import mill.scalalib._
+import mill.scalalib.scalafmt._
 import mill.scalanativelib._
 import mill.scalalib.publish._
 import mill.scalalib.api.ZincWorkerUtil
@@ -124,7 +125,8 @@ trait SafeDeps extends ScalaModule {
   }
 }
 
-trait OsLibModule extends CrossScalaModule with PublishModule with AcyclicModule with SafeDeps {
+trait OsLibModule extends CrossScalaModule with PublishModule with AcyclicModule with SafeDeps
+    with ScalafmtModule {
   def publishVersion = VcsVersion.vcsState().format()
   def pomSettings = PomSettings(
     description = artifactName(),

--- a/os/src-jvm/ProcessOps.scala
+++ b/os/src-jvm/ProcessOps.scala
@@ -5,74 +5,76 @@ import java.util.concurrent.{ArrayBlockingQueue, Semaphore, TimeUnit}
 import scala.annotation.tailrec
 
 /**
-  * Convenience APIs around [[java.lang.Process]] and [[java.lang.ProcessBuilder]]:
-  *
-  * - os.proc.call provides a convenient wrapper for "function-like" processes
-  *   that you invoke with some input, whose entire output you need, but
-  *   otherwise do not have any intricate back-and-forth communication
-  *
-  * - os.proc.stream provides a lower level API: rather than providing the output
-  *   all at once, you pass in callbacks it invokes whenever there is a chunk of
-  *   output received from the spawned process.
-  *
-  * - os.proc(...) provides the lowest level API: an simple Scala API around
-  *   [[java.lang.ProcessBuilder]], that spawns a normal [[java.lang.Process]]
-  *   for you to deal with. You can then interact with it normally through
-  *   the standard stdin/stdout/stderr streams, using whatever protocol you
-  *   want
-  */
+ * Convenience APIs around [[java.lang.Process]] and [[java.lang.ProcessBuilder]]:
+ *
+ * - os.proc.call provides a convenient wrapper for "function-like" processes
+ *   that you invoke with some input, whose entire output you need, but
+ *   otherwise do not have any intricate back-and-forth communication
+ *
+ * - os.proc.stream provides a lower level API: rather than providing the output
+ *   all at once, you pass in callbacks it invokes whenever there is a chunk of
+ *   output received from the spawned process.
+ *
+ * - os.proc(...) provides the lowest level API: an simple Scala API around
+ *   [[java.lang.ProcessBuilder]], that spawns a normal [[java.lang.Process]]
+ *   for you to deal with. You can then interact with it normally through
+ *   the standard stdin/stdout/stderr streams, using whatever protocol you
+ *   want
+ */
 case class proc(command: Shellable*) {
   def commandChunks: Seq[String] = command.flatMap(_.value)
 
   /**
-    * Invokes the given subprocess like a function, passing in input and returning a
-    * [[CommandResult]]. You can then call `result.exitCode` to see how it exited, or
-    * `result.out.bytes` or `result.err.string` to access the aggregated stdout and
-    * stderr of the subprocess in a number of convenient ways. If a non-zero exit code
-    * is returned, this throws a [[os.SubprocessException]] containing the
-    * [[CommandResult]], unless you pass in `check = false`.
-    *
-    * If you want to spawn an interactive subprocess, such as `vim`, `less`, or a
-    * `python` shell, set all of `stdin`/`stdout`/`stderr` to [[os.Inherit]]
-    *
-    * `call` provides a number of parameters that let you configure how the subprocess
-    * is run:
-    *
-    * @param cwd             the working directory of the subprocess
-    * @param env             any additional environment variables you wish to set in the subprocess
-    * @param stdin           any data you wish to pass to the subprocess's standard input
-    * @param stdout          How the process's output stream is configured.
-    * @param stderr          How the process's error stream is configured.
-    * @param mergeErrIntoOut merges the subprocess's stderr stream into it's stdout
-    * @param timeout         how long to wait in milliseconds for the subprocess to complete
-    * @param check           disable this to avoid throwing an exception if the subprocess
-    *                        fails with a non-zero exit code
-    * @param propagateEnv    disable this to avoid passing in this parent process's
-    *                        environment variables to the subprocess
-    */
-  def call(cwd: Path = null,
-           env: Map[String, String] = null,
-           stdin: ProcessInput = Pipe,
-           stdout: ProcessOutput = Pipe,
-           stderr: ProcessOutput = os.Inherit,
-           mergeErrIntoOut: Boolean = false,
-           timeout: Long = -1,
-           check: Boolean = true,
-           propagateEnv: Boolean = true)
-            : CommandResult = {
+   * Invokes the given subprocess like a function, passing in input and returning a
+   * [[CommandResult]]. You can then call `result.exitCode` to see how it exited, or
+   * `result.out.bytes` or `result.err.string` to access the aggregated stdout and
+   * stderr of the subprocess in a number of convenient ways. If a non-zero exit code
+   * is returned, this throws a [[os.SubprocessException]] containing the
+   * [[CommandResult]], unless you pass in `check = false`.
+   *
+   * If you want to spawn an interactive subprocess, such as `vim`, `less`, or a
+   * `python` shell, set all of `stdin`/`stdout`/`stderr` to [[os.Inherit]]
+   *
+   * `call` provides a number of parameters that let you configure how the subprocess
+   * is run:
+   *
+   * @param cwd             the working directory of the subprocess
+   * @param env             any additional environment variables you wish to set in the subprocess
+   * @param stdin           any data you wish to pass to the subprocess's standard input
+   * @param stdout          How the process's output stream is configured.
+   * @param stderr          How the process's error stream is configured.
+   * @param mergeErrIntoOut merges the subprocess's stderr stream into it's stdout
+   * @param timeout         how long to wait in milliseconds for the subprocess to complete
+   * @param check           disable this to avoid throwing an exception if the subprocess
+   *                        fails with a non-zero exit code
+   * @param propagateEnv    disable this to avoid passing in this parent process's
+   *                        environment variables to the subprocess
+   */
+  def call(
+      cwd: Path = null,
+      env: Map[String, String] = null,
+      stdin: ProcessInput = Pipe,
+      stdout: ProcessOutput = Pipe,
+      stderr: ProcessOutput = os.Inherit,
+      mergeErrIntoOut: Boolean = false,
+      timeout: Long = -1,
+      check: Boolean = true,
+      propagateEnv: Boolean = true
+  ): CommandResult = {
 
     val chunks = new java.util.concurrent.ConcurrentLinkedQueue[Either[geny.Bytes, geny.Bytes]]
 
     val sub = spawn(
-      cwd, env,
+      cwd,
+      env,
       stdin,
       if (stdout ne os.Pipe) stdout
-      else os.ProcessOutput.ReadBytes(
-        (buf, n) => chunks.add(Left(new geny.Bytes(java.util.Arrays.copyOf(buf, n))))
+      else os.ProcessOutput.ReadBytes((buf, n) =>
+        chunks.add(Left(new geny.Bytes(java.util.Arrays.copyOf(buf, n))))
       ),
       if (stderr ne os.Pipe) stderr
-      else os.ProcessOutput.ReadBytes(
-        (buf, n) => chunks.add(Right(new geny.Bytes(java.util.Arrays.copyOf(buf, n))))
+      else os.ProcessOutput.ReadBytes((buf, n) =>
+        chunks.add(Right(new geny.Bytes(java.util.Arrays.copyOf(buf, n))))
       ),
       mergeErrIntoOut,
       propagateEnv
@@ -88,31 +90,33 @@ case class proc(command: Shellable*) {
   }
 
   /**
-    * The most flexible of the [[os.proc]] calls, `os.proc.spawn` simply configures
-    * and starts a subprocess, and returns it as a `java.lang.Process` for you to
-    * interact with however you like.
-    *
-    * To implement pipes, you can spawn a process, take it's stdout, and pass it
-    * as the stdin of a second spawned process.
-    *
-    * Note that if you provide `ProcessOutput` callbacks to `stdout`/`stderr`,
-    * the calls to those callbacks take place on newly spawned threads that
-    * execute in parallel with the main thread. Thus make sure any data
-    * processing you do in those callbacks is thread safe!
-    */
-  def spawn(cwd: Path = null,
-            env: Map[String, String] = null,
-            stdin: ProcessInput = Pipe,
-            stdout: ProcessOutput = Pipe,
-            stderr: ProcessOutput = os.Inherit,
-            mergeErrIntoOut: Boolean = false,
-            propagateEnv: Boolean = true): SubProcess = {
+   * The most flexible of the [[os.proc]] calls, `os.proc.spawn` simply configures
+   * and starts a subprocess, and returns it as a `java.lang.Process` for you to
+   * interact with however you like.
+   *
+   * To implement pipes, you can spawn a process, take it's stdout, and pass it
+   * as the stdin of a second spawned process.
+   *
+   * Note that if you provide `ProcessOutput` callbacks to `stdout`/`stderr`,
+   * the calls to those callbacks take place on newly spawned threads that
+   * execute in parallel with the main thread. Thus make sure any data
+   * processing you do in those callbacks is thread safe!
+   */
+  def spawn(
+      cwd: Path = null,
+      env: Map[String, String] = null,
+      stdin: ProcessInput = Pipe,
+      stdout: ProcessOutput = Pipe,
+      stderr: ProcessOutput = os.Inherit,
+      mergeErrIntoOut: Boolean = false,
+      propagateEnv: Boolean = true
+  ): SubProcess = {
     val builder = new java.lang.ProcessBuilder()
 
     val baseEnv =
       if (propagateEnv) sys.env
       else Map()
-    for ((k, v) <- baseEnv ++ Option(env).getOrElse(Map())){
+    for ((k, v) <- baseEnv ++ Option(env).getOrElse(Map())) {
       if (v != null) builder.environment().put(k, v)
       else builder.environment().remove(k)
     }
@@ -123,7 +127,7 @@ case class proc(command: Shellable*) {
     val commandStr = cmdChunks.mkString(" ")
     lazy val proc: SubProcess = new SubProcess(
       builder
-        .command(cmdChunks:_*)
+        .command(cmdChunks: _*)
         .redirectInput(stdin.redirectFrom)
         .redirectOutput(stdout.redirectTo)
         .redirectError(stderr.redirectTo)

--- a/os/src-jvm/ResourcePath.scala
+++ b/os/src-jvm/ResourcePath.scala
@@ -4,20 +4,20 @@ import java.io.InputStream
 
 import scala.language.implicitConversions
 
-object ResourcePath{
+object ResourcePath {
   def resource(resRoot: ResourceRoot) = {
     new ResourcePath(resRoot, Array.empty[String])
   }
 }
 
 /**
-  * Represents path to a resource on the java classpath.
-  *
-  * Classloaders are tricky: http://stackoverflow.com/questions/12292926
-  */
-class ResourcePath private[os](val resRoot: ResourceRoot, segments0: Array[String])
-  extends BasePathImpl with ReadablePath with SegmentedPath {
-  def getInputStream = resRoot.getResourceAsStream(segments.mkString("/")) match{
+ * Represents path to a resource on the java classpath.
+ *
+ * Classloaders are tricky: http://stackoverflow.com/questions/12292926
+ */
+class ResourcePath private[os] (val resRoot: ResourceRoot, segments0: Array[String])
+    extends BasePathImpl with ReadablePath with SegmentedPath {
+  def getInputStream = resRoot.getResourceAsStream(segments.mkString("/")) match {
     case null => throw ResourceNotFoundException(this)
     case stream => stream
   }
@@ -27,7 +27,7 @@ class ResourcePath private[os](val resRoot: ResourceRoot, segments0: Array[Strin
   def lastOpt = segments0.lastOption
   override def toString = resRoot.errorName + "/" + segments0.mkString("/")
   protected[this] def make(p: Seq[String], ups: Int) = {
-    if (ups > 0){
+    if (ups > 0) {
       throw PathError.AbsolutePathOutsideRoot
     }
     new ResourcePath(resRoot, p.toArray[String])
@@ -37,13 +37,12 @@ class ResourcePath private[os](val resRoot: ResourceRoot, segments0: Array[Strin
     var newUps = 0
     var s2 = base.segments
 
-    while(!segments0.startsWith(s2)){
+    while (!segments0.startsWith(s2)) {
       s2 = s2.dropRight(1)
       newUps += 1
     }
     new RelPath(segments0.drop(s2.length), newUps)
   }
-
 
   def startsWith(target: ResourcePath) = {
     segments0.startsWith(target.segments)
@@ -52,36 +51,34 @@ class ResourcePath private[os](val resRoot: ResourceRoot, segments0: Array[Strin
 }
 
 /**
-  * Thrown when you try to read from a resource that doesn't exist.
-  * @param path
-  */
+ * Thrown when you try to read from a resource that doesn't exist.
+ * @param path
+ */
 case class ResourceNotFoundException(path: ResourcePath) extends Exception(path.toString)
 
-
 /**
-  * Represents a possible root where classpath resources can be loaded from;
-  * either a [[ResourceRoot.ClassLoader]] or a [[ResourceRoot.Class]]. Resources
-  * loaded from classloaders are always loaded via their absolute path, while
-  * resources loaded via classes are always loaded relatively.
-  */
-sealed trait ResourceRoot{
+ * Represents a possible root where classpath resources can be loaded from;
+ * either a [[ResourceRoot.ClassLoader]] or a [[ResourceRoot.Class]]. Resources
+ * loaded from classloaders are always loaded via their absolute path, while
+ * resources loaded via classes are always loaded relatively.
+ */
+sealed trait ResourceRoot {
   def getResourceAsStream(s: String): InputStream
   def errorName: String
 }
-object ResourceRoot{
+object ResourceRoot {
   private[this] def renderClassloader(cl: java.lang.ClassLoader) = {
     cl.getClass.getName + "@" + java.lang.Integer.toHexString(cl.hashCode())
   }
   implicit def classResourceRoot(cls: java.lang.Class[_]): ResourceRoot = Class(cls)
-  case class Class(cls: java.lang.Class[_]) extends ResourceRoot{
+  case class Class(cls: java.lang.Class[_]) extends ResourceRoot {
     def getResourceAsStream(s: String) = cls.getResourceAsStream(s)
     def errorName = renderClassloader(cls.getClassLoader) + ":" + cls.getName
   }
   implicit def classLoaderResourceRoot(cl: java.lang.ClassLoader): ResourceRoot = ClassLoader(cl)
-  case class ClassLoader(cl: java.lang.ClassLoader) extends ResourceRoot{
+  case class ClassLoader(cl: java.lang.ClassLoader) extends ResourceRoot {
     def getResourceAsStream(s: String) = cl.getResourceAsStream(s)
     def errorName = renderClassloader(cl)
   }
 
 }
-

--- a/os/src-jvm/package.scala
+++ b/os/src-jvm/package.scala
@@ -1,7 +1,6 @@
-
 import scala.language.implicitConversions
 
-package object os{
+package object os {
   type Generator[+T] = geny.Generator[T]
   val Generator = geny.Generator
   implicit def GlobSyntax(s: StringContext): GlobInterpolator = new GlobInterpolator(s)
@@ -11,7 +10,7 @@ package object os{
    */
   val root: Path = Path(java.nio.file.Paths.get(".").toAbsolutePath.getRoot)
 
-  def resource(implicit resRoot: ResourceRoot = Thread.currentThread().getContextClassLoader) ={
+  def resource(implicit resRoot: ResourceRoot = Thread.currentThread().getContextClassLoader) = {
     os.ResourcePath.resource(resRoot)
   }
 
@@ -30,19 +29,20 @@ package object os{
   val rel: RelPath = RelPath.rel
 
   val sub: SubPath = SubPath.sub
+
   /**
-    * Extractor to let you easily pattern match on [[os.Path]]s. Lets you do
-    *
-    * {{{
-    *   @ val base/segment/filename = pwd
-    *   base: Path = Path(Vector("Users", "haoyi", "Dropbox (Personal)"))
-    *   segment: String = "Workspace"
-    *   filename: String = "Ammonite"
-    * }}}
-    *
-    * To break apart a path and extract various pieces of it.
-    */
-  object /{
+   * Extractor to let you easily pattern match on [[os.Path]]s. Lets you do
+   *
+   * {{{
+   *   @ val base/segment/filename = pwd
+   *   base: Path = Path(Vector("Users", "haoyi", "Dropbox (Personal)"))
+   *   segment: String = "Workspace"
+   *   filename: String = "Ammonite"
+   * }}}
+   *
+   * To break apart a path and extract various pieces of it.
+   */
+  object / {
     def unapply(p: Path): Option[(Path, String)] = {
       if (p.segmentCount != 0) Some((p / up, p.last))
       else None

--- a/os/src-native/package.scala
+++ b/os/src-native/package.scala
@@ -1,5 +1,4 @@
-
-package object os{
+package object os {
   type Generator[+T] = geny.Generator[T]
   val Generator = geny.Generator
   implicit def GlobSyntax(s: StringContext): GlobInterpolator = new GlobInterpolator(s)
@@ -24,19 +23,20 @@ package object os{
   val rel: RelPath = RelPath.rel
 
   val sub: SubPath = SubPath.sub
+
   /**
-    * Extractor to let you easily pattern match on [[os.Path]]s. Lets you do
-    *
-    * {{{
-    *   @ val base/segment/filename = pwd
-    *   base: Path = Path(Vector("Users", "haoyi", "Dropbox (Personal)"))
-    *   segment: String = "Workspace"
-    *   filename: String = "Ammonite"
-    * }}}
-    *
-    * To break apart a path and extract various pieces of it.
-    */
-  object /{
+   * Extractor to let you easily pattern match on [[os.Path]]s. Lets you do
+   *
+   * {{{
+   *   @ val base/segment/filename = pwd
+   *   base: Path = Path(Vector("Users", "haoyi", "Dropbox (Personal)"))
+   *   segment: String = "Workspace"
+   *   filename: String = "Ammonite"
+   * }}}
+   *
+   * To break apart a path and extract various pieces of it.
+   */
+  object / {
     def unapply(p: Path): Option[(Path, String)] = {
       if (p.segmentCount != 0) Some((p / up, p.last))
       else None

--- a/os/src/FileOps.scala
+++ b/os/src/FileOps.scala
@@ -12,17 +12,16 @@ import java.nio.file.attribute.{FileAttribute, PosixFilePermission, PosixFilePer
 
 import scala.util.Try
 
-
 /**
  * Create a single directory at the specified path. Optionally takes in a
-  * [[PermSet]] to specify the filesystem permissions of the created
-  * directory.
-  *
-  * Errors out if the directory already exists, or if the parent directory of the
-  * specified path does not exist. To automatically create enclosing directories and
-  * ignore the destination if it already exists, using [[os.makeDir.all]]
+ * [[PermSet]] to specify the filesystem permissions of the created
+ * directory.
+ *
+ * Errors out if the directory already exists, or if the parent directory of the
+ * specified path does not exist. To automatically create enclosing directories and
+ * ignore the destination if it already exists, using [[os.makeDir.all]]
  */
-object makeDir extends Function1[Path, Unit]{
+object makeDir extends Function1[Path, Unit] {
   def apply(path: Path): Unit = Files.createDirectory(path.wrapped)
   def apply(path: Path, perms: PermSet): Unit = {
     Files.createDirectory(
@@ -30,12 +29,13 @@ object makeDir extends Function1[Path, Unit]{
       PosixFilePermissions.asFileAttribute(perms.toSet())
     )
   }
+
   /**
-    * Similar to [[os.makeDir]], but automatically creates any necessary
-    * enclosing directories if they do not exist, and does not raise an error if the
-    * destination path already containts a directory
-    */
-  object all extends Function1[Path, Unit]{
+   * Similar to [[os.makeDir]], but automatically creates any necessary
+   * enclosing directories if they do not exist, and does not raise an error if the
+   * destination path already containts a directory
+   */
+  object all extends Function1[Path, Unit] {
     def apply(path: Path): Unit = apply(path, null, true)
     def apply(path: Path, perms: PermSet = null, acceptLinkedDirectory: Boolean = true): Unit = {
       // We special case calling makeDir.all on a symlink to a directory;
@@ -54,21 +54,21 @@ object makeDir extends Function1[Path, Unit]{
   }
 }
 
-
 /**
-  * Moves a file or folder from one path to another. Errors out if the destination
-  * path already exists, or is within the source path.
+ * Moves a file or folder from one path to another. Errors out if the destination
+ * path already exists, or is within the source path.
  */
 object move {
-  def matching(replaceExisting: Boolean = false,
-               atomicMove: Boolean = false,
-               createFolders: Boolean = false)
-              (partialFunction: PartialFunction[Path, Path]): PartialFunction[Path, Unit] = {
+  def matching(
+      replaceExisting: Boolean = false,
+      atomicMove: Boolean = false,
+      createFolders: Boolean = false
+  )(partialFunction: PartialFunction[Path, Path]): PartialFunction[Path, Unit] = {
     new PartialFunction[Path, Unit] {
       def isDefinedAt(x: Path) = partialFunction.isDefinedAt(x)
       def apply(from: Path) = {
         val dest = partialFunction(from)
-        makeDir.all(dest/up)
+        makeDir.all(dest / up)
         os.move(from, dest, replaceExisting, atomicMove, createFolders)
       }
     }
@@ -77,12 +77,14 @@ object move {
   def matching(partialFunction: PartialFunction[Path, Path]): PartialFunction[Path, Unit] = {
     matching()(partialFunction)
   }
-  def apply(from: Path,
-            to: Path,
-            replaceExisting: Boolean = false,
-            atomicMove: Boolean = false,
-            createFolders: Boolean = false): Unit = {
-    if (createFolders) makeDir.all(to/up)
+  def apply(
+      from: Path,
+      to: Path,
+      replaceExisting: Boolean = false,
+      atomicMove: Boolean = false,
+      createFolders: Boolean = false
+  ): Unit = {
+    if (createFolders) makeDir.all(to / up)
     val opts1 =
       if (replaceExisting) Array[CopyOption](StandardCopyOption.REPLACE_EXISTING)
       else Array[CopyOption]()
@@ -93,33 +95,37 @@ object move {
       !to.startsWith(from),
       s"Can't move a directory into itself: $to is inside $from"
     )
-    java.nio.file.Files.move(from.wrapped, to.wrapped, opts1 ++ opts2:_*)
+    java.nio.file.Files.move(from.wrapped, to.wrapped, opts1 ++ opts2: _*)
   }
 
   /**
-    * Move a file into a particular folder, rather
-    * than into a particular path
-    */
+   * Move a file into a particular folder, rather
+   * than into a particular path
+   */
   object into {
-    def apply(from: Path,
-              to: Path,
-              replaceExisting: Boolean = false,
-              atomicMove: Boolean = false,
-              createFolders: Boolean = false): Unit = {
-      move.apply(from, to/from.last, replaceExisting, atomicMove, createFolders)
+    def apply(
+        from: Path,
+        to: Path,
+        replaceExisting: Boolean = false,
+        atomicMove: Boolean = false,
+        createFolders: Boolean = false
+    ): Unit = {
+      move.apply(from, to / from.last, replaceExisting, atomicMove, createFolders)
     }
   }
 
   /**
-    * Move a file into a particular folder, rather
-    * than into a particular path
-    */
+   * Move a file into a particular folder, rather
+   * than into a particular path
+   */
   object over {
-    def apply(from: Path,
-              to: Path,
-              replaceExisting: Boolean = false,
-              atomicMove: Boolean = false,
-              createFolders: Boolean = false): Unit = {
+    def apply(
+        from: Path,
+        to: Path,
+        replaceExisting: Boolean = false,
+        atomicMove: Boolean = false,
+        createFolders: Boolean = false
+    ): Unit = {
       os.remove.all(to)
       move.apply(from, to, replaceExisting, atomicMove, createFolders)
     }
@@ -127,24 +133,31 @@ object move {
 }
 
 /**
-  * Copy a file or folder from one path to another. Recursively copies folders with
-  * all their contents. Errors out if the destination path already exists, or is
-  * within the source path.
+ * Copy a file or folder from one path to another. Recursively copies folders with
+ * all their contents. Errors out if the destination path already exists, or is
+ * within the source path.
  */
 object copy {
-  def matching(followLinks: Boolean = true,
-               replaceExisting: Boolean = false,
-               copyAttributes: Boolean = false,
-               createFolders: Boolean = false,
-               mergeFolders: Boolean = false)
-              (partialFunction: PartialFunction[Path, Path]): PartialFunction[Path, Unit] = {
+  def matching(
+      followLinks: Boolean = true,
+      replaceExisting: Boolean = false,
+      copyAttributes: Boolean = false,
+      createFolders: Boolean = false,
+      mergeFolders: Boolean = false
+  )(partialFunction: PartialFunction[Path, Path]): PartialFunction[Path, Unit] = {
     new PartialFunction[Path, Unit] {
       def isDefinedAt(x: Path) = partialFunction.isDefinedAt(x)
       def apply(from: Path) = {
         val dest = partialFunction(from)
-        makeDir.all(dest/up)
+        makeDir.all(dest / up)
         os.copy(
-          from, dest, followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders
+          from,
+          dest,
+          followLinks,
+          replaceExisting,
+          copyAttributes,
+          createFolders,
+          mergeFolders
         )
       }
     }
@@ -155,14 +168,14 @@ object copy {
   }
 
   def apply(
-             from: Path,
-             to: Path,
-             followLinks: Boolean = true,
-             replaceExisting: Boolean = false,
-             copyAttributes: Boolean = false,
-             createFolders: Boolean = false,
-             mergeFolders: Boolean = false
-           ): Unit = {
+      from: Path,
+      to: Path,
+      followLinks: Boolean = true,
+      replaceExisting: Boolean = false,
+      copyAttributes: Boolean = false,
+      createFolders: Boolean = false,
+      mergeFolders: Boolean = false
+  ): Unit = {
     if (createFolders) makeDir.all(to / up)
     val opts1 =
       if (followLinks) Array[CopyOption]()
@@ -192,16 +205,19 @@ object copy {
     if (stat(from, followLinks = followLinks).isDir) walk(from).map(copyOne)
   }
 
-  /** This overload is only to keep binary compatibility with older os-lib versions.  */
-  @deprecated("Use os.copy(from, to, followLinks, replaceExisting, copyAttributes, " +
-    "createFolders, mergeFolders) instead", "os-lib 0.7.5")
+  /** This overload is only to keep binary compatibility with older os-lib versions. */
+  @deprecated(
+    "Use os.copy(from, to, followLinks, replaceExisting, copyAttributes, " +
+      "createFolders, mergeFolders) instead",
+    "os-lib 0.7.5"
+  )
   def apply(
-    from: Path,
-    to: Path,
-    followLinks: Boolean,
-    replaceExisting: Boolean,
-    copyAttributes: Boolean,
-    createFolders: Boolean
+      from: Path,
+      to: Path,
+      followLinks: Boolean,
+      replaceExisting: Boolean,
+      copyAttributes: Boolean,
+      createFolders: Boolean
   ): Unit = apply(
     from = from,
     to = to,
@@ -213,33 +229,43 @@ object copy {
   )
 
   /**
-    * Copy a file into a particular folder, rather
-    * than into a particular path
-    */
+   * Copy a file into a particular folder, rather
+   * than into a particular path
+   */
   object into {
-    def apply(from: Path,
-              to: Path,
-              followLinks: Boolean = true,
-              replaceExisting: Boolean = false,
-              copyAttributes: Boolean = false,
-              createFolders: Boolean = false,
-              mergeFolders: Boolean = false): Unit = {
+    def apply(
+        from: Path,
+        to: Path,
+        followLinks: Boolean = true,
+        replaceExisting: Boolean = false,
+        copyAttributes: Boolean = false,
+        createFolders: Boolean = false,
+        mergeFolders: Boolean = false
+    ): Unit = {
       os.copy(
-        from, to/from.last,
-        followLinks, replaceExisting, copyAttributes, createFolders, mergeFolders
+        from,
+        to / from.last,
+        followLinks,
+        replaceExisting,
+        copyAttributes,
+        createFolders,
+        mergeFolders
       )
     }
 
-    /** This overload is only to keep binary compatibility with older os-lib versions.  */
-    @deprecated("Use os.copy.into(from, to, followLinks, replaceExisting, copyAttributes, " +
-      "createFolders, mergeFolders) instead", "os-lib 0.7.5")
+    /** This overload is only to keep binary compatibility with older os-lib versions. */
+    @deprecated(
+      "Use os.copy.into(from, to, followLinks, replaceExisting, copyAttributes, " +
+        "createFolders, mergeFolders) instead",
+      "os-lib 0.7.5"
+    )
     def apply(
-      from: Path,
-      to: Path,
-      followLinks: Boolean,
-      replaceExisting: Boolean,
-      copyAttributes: Boolean,
-      createFolders: Boolean
+        from: Path,
+        to: Path,
+        followLinks: Boolean,
+        replaceExisting: Boolean,
+        copyAttributes: Boolean,
+        createFolders: Boolean
     ): Unit = apply(
       from = from,
       to = to,
@@ -252,15 +278,17 @@ object copy {
   }
 
   /**
-    * Copy a file into a particular path
-    */
-  object over{
-    def apply(from: Path,
-              to: Path,
-              followLinks: Boolean = true,
-              replaceExisting: Boolean = false,
-              copyAttributes: Boolean = false,
-              createFolders: Boolean = false): Unit = {
+   * Copy a file into a particular path
+   */
+  object over {
+    def apply(
+        from: Path,
+        to: Path,
+        followLinks: Boolean = true,
+        replaceExisting: Boolean = false,
+        copyAttributes: Boolean = false,
+        createFolders: Boolean = false
+    ): Unit = {
       os.remove.all(to)
       os.copy(
         from = from,
@@ -280,18 +308,18 @@ object copy {
  * any files or folders in the target path, or
  * does nothing if there aren't any
  */
-object remove extends Function1[Path, Boolean]{
+object remove extends Function1[Path, Boolean] {
   def apply(target: Path): Boolean = apply(target, false)
   def apply(target: Path, checkExists: Boolean = false): Boolean = {
     if (checkExists) {
       Files.delete(target.wrapped)
       true
-    }else{
+    } else {
       Files.deleteIfExists(target.wrapped)
     }
   }
 
-  object all extends Function1[Path, Unit]{
+  object all extends Function1[Path, Unit] {
     def apply(target: Path) = {
       require(target.segmentCount != 0, s"Cannot remove a root directory: $target")
 
@@ -307,19 +335,19 @@ object remove extends Function1[Path, Boolean]{
 }
 
 /**
-  * Checks if a file or folder exists at the given path.
-  */
-object exists extends Function1[Path, Boolean]{
+ * Checks if a file or folder exists at the given path.
+ */
+object exists extends Function1[Path, Boolean] {
   def apply(p: Path): Boolean = Files.exists(p.wrapped)
   def apply(p: Path, followLinks: Boolean = true): Boolean = {
     val opts = if (followLinks) Array[LinkOption]() else Array(LinkOption.NOFOLLOW_LINKS)
-    Files.exists(p.wrapped, opts:_*)
+    Files.exists(p.wrapped, opts: _*)
   }
 }
 
 /**
-  * Creates a hardlink between two paths
-  */
+ * Creates a hardlink between two paths
+ */
 object hardlink {
   def apply(link: Path, dest: Path) = {
     Files.createLink(link.wrapped, dest.wrapped)
@@ -327,8 +355,8 @@ object hardlink {
 }
 
 /**
-  * Creates a symbolic link between two paths
-  */
+ * Creates a symbolic link between two paths
+ */
 object symlink {
   def apply(link: Path, dest: FilePath, perms: PermSet = null): Unit = {
     val permArray: Array[FileAttribute[_]] =
@@ -337,34 +365,31 @@ object symlink {
 
     Files.createSymbolicLink(
       link.toNIO,
-      dest match{
+      dest match {
         // Special case empty relative paths, because for some reason `createSymbolicLink`
         // doesn't like it when the path is "" (most other Files.* functions are fine)
         case p: RelPath if p.segments.isEmpty && p.ups == 0 => java.nio.file.Paths.get(".")
         case p: SubPath if p.segments.isEmpty => java.nio.file.Paths.get(".")
         case _ => dest.toNIO
       },
-      permArray:_*
+      permArray: _*
     )
   }
 }
 
-
 /**
-  * Attempts to any symbolic links in the given path and return the canonical path.
-  * Returns `None` if the path cannot be resolved (i.e. some symbolic link in the
-  * given path is broken)
-  */
-object followLink extends Function1[Path, Option[Path]]{
+ * Attempts to any symbolic links in the given path and return the canonical path.
+ * Returns `None` if the path cannot be resolved (i.e. some symbolic link in the
+ * given path is broken)
+ */
+object followLink extends Function1[Path, Option[Path]] {
   def apply(src: Path): Option[Path] = Try(Path(src.wrapped.toRealPath())).toOption
 }
 
-
 /**
-  * Reads the destination that the given symbolic link is pointed to
-  */
-object readLink extends Function1[Path, os.FilePath]{
+ * Reads the destination that the given symbolic link is pointed to
+ */
+object readLink extends Function1[Path, os.FilePath] {
   def apply(src: Path): FilePath = os.FilePath(Files.readSymbolicLink(src.toNIO))
   def absolute(src: Path): os.Path = os.Path(Files.readSymbolicLink(src.toNIO), src / up)
 }
-

--- a/os/src/GlobInterpolator.scala
+++ b/os/src/GlobInterpolator.scala
@@ -1,10 +1,9 @@
 package os
 
-
-object GlobInterpolator{
-  class Interped(parts: Seq[String]){
+object GlobInterpolator {
+  class Interped(parts: Seq[String]) {
     def unapplySeq(s: String) = {
-      val Seq(head, tail@_*) = parts.map(java.util.regex.Pattern.quote)
+      val Seq(head, tail @ _*) = parts.map(java.util.regex.Pattern.quote)
 
       val regex = head + tail.map("(.*)" + _).mkString
       regex.r.unapplySeq(s)
@@ -13,9 +12,9 @@ object GlobInterpolator{
 }
 
 /**
-  * Lets you pattern match strings with interpolated glob-variables
-  */
+ * Lets you pattern match strings with interpolated glob-variables
+ */
 class GlobInterpolator(sc: StringContext) {
-  def g(parts: Any*) = new StringContext(sc.parts:_*).s(parts:_*)
+  def g(parts: Any*) = new StringContext(sc.parts: _*).s(parts: _*)
   def g = new GlobInterpolator.Interped(sc.parts)
 }

--- a/os/src/Internals.scala
+++ b/os/src/Internals.scala
@@ -3,12 +3,11 @@ package os
 import java.io.{InputStream, OutputStream}
 import java.nio.file.Files
 
-object Internals{
+object Internals {
 
   val emptyStringArray = Array.empty[String]
 
-  def transfer0(src: InputStream,
-                sink: (Array[Byte], Int) => Unit) = {
+  def transfer0(src: InputStream, sink: (Array[Byte], Int) => Unit) = {
     val buffer = new Array[Byte](8192)
     var r = 0
     while (r != -1) {

--- a/os/src/ListOps.scala
+++ b/os/src/ListOps.scala
@@ -6,14 +6,14 @@ import java.nio.file.{Path => _, _}
 import java.nio.file.attribute.BasicFileAttributes
 
 /**
-  * Returns all the files and folders directly within the given folder. If the
-  * given path is not a folder, raises an error. Can be called with
-  * [[list.stream]] to return an iterator. To list files recursively, use
-  * [[walk]]
-  *
-  * For convenience `os.list` sorts the entries in the folder before returning
-  * them. You can disable sorted by passing in the flag `sort = false`.
-  */
+ * Returns all the files and folders directly within the given folder. If the
+ * given path is not a folder, raises an error. Can be called with
+ * [[list.stream]] to return an iterator. To list files recursively, use
+ * [[walk]]
+ *
+ * For convenience `os.list` sorts the entries in the folder before returning
+ * them. You can disable sorted by passing in the flag `sort = false`.
+ */
 object list extends Function1[Path, IndexedSeq[Path]] {
   def apply(src: Path, sort: Boolean = true): IndexedSeq[Path] = {
     val arr = stream(src).toArray[Path]
@@ -23,18 +23,18 @@ object list extends Function1[Path, IndexedSeq[Path]] {
   def apply(src: Path): IndexedSeq[Path] = apply(src, true).toIndexedSeq
 
   /**
-    * Similar to [[os.list]]], except provides a [[os.Generator]] of results
-    * rather than accumulating all of them in memory. Useful if the result set
-    * is large.
-    */
-  object stream extends Function1[Path, geny.Generator[Path]]{
+   * Similar to [[os.list]]], except provides a [[os.Generator]] of results
+   * rather than accumulating all of them in memory. Useful if the result set
+   * is large.
+   */
+  object stream extends Function1[Path, geny.Generator[Path]] {
     def apply(arg: Path) = new Generator[Path] {
       def generate(handleItem: Path => Generator.Action) = {
         val ds = Files.newDirectoryStream(arg.toNIO)
         val iter = ds.iterator()
         var currentAction: Generator.Action = Generator.Continue
         try {
-          while (iter.hasNext && currentAction == Generator.Continue){
+          while (iter.hasNext && currentAction == Generator.Continue) {
             currentAction = handleItem(Path(iter.next().toAbsolutePath))
           }
         } finally ds.close()
@@ -45,82 +45,87 @@ object list extends Function1[Path, IndexedSeq[Path]] {
 }
 
 /**
-  * Recursively walks the given folder and returns the paths of every file or folder
-  * within.
-  *
-  * You can pass in a `skip` callback to skip files or folders you are not
-  * interested in. This can avoid walking entire parts of the folder hierarchy,
-  * saving time as compared to filtering them after the fact.
-  *
-  * By default, the paths are returned as a pre-order traversal: the enclosing
-  * folder is occurs first before any of it's contents. You can pass in `preOrder =
-  * false` to turn it into a post-order traversal, such that the enclosing folder
-  * occurs last after all it's contents.
-  *
-  * `os.walk` returns but does not follow symlinks; pass in `followLinks = true` to
-  * override that behavior. You can also specify a maximum depth you wish to walk
-  * via the `maxDepth` parameter.
-  */
+ * Recursively walks the given folder and returns the paths of every file or folder
+ * within.
+ *
+ * You can pass in a `skip` callback to skip files or folders you are not
+ * interested in. This can avoid walking entire parts of the folder hierarchy,
+ * saving time as compared to filtering them after the fact.
+ *
+ * By default, the paths are returned as a pre-order traversal: the enclosing
+ * folder is occurs first before any of it's contents. You can pass in `preOrder =
+ * false` to turn it into a post-order traversal, such that the enclosing folder
+ * occurs last after all it's contents.
+ *
+ * `os.walk` returns but does not follow symlinks; pass in `followLinks = true` to
+ * override that behavior. You can also specify a maximum depth you wish to walk
+ * via the `maxDepth` parameter.
+ */
 object walk {
+
   /**
-    * @param path the root path whose contents you wish to walk
-    *
-    * @param skip Skip certain files or folders from appearing in the output.
-    *             If you skip a folder, its entire subtree is ignored
-    *
-    * @param preOrder Whether you want a folder to appear before or after its
-    *                 contents in the final sequence. e.g. if you're deleting
-    *                 them recursively you want it to be false so the folder
-    *                 gets deleted last, but if you're copying them recursively
-    *                 you want `preOrder` to be `true` so the folder gets
-    *                 created first.
-    *
-    * @param followLinks Whether or not to follow symlinks while walking; defaults
-    *                    to false
-    *
-    * @param maxDepth The max depth of the tree you wish to walk; defaults to unlimited
-    *
-    * @param includeTarget Whether or not to include the given path as part of the walk.
-    *                      If `true`, does not raise an error if the given path is a
-    *                      simple file and not a folder
-    */
-  def apply(path: Path,
-            skip: Path => Boolean = _ => false,
-            preOrder: Boolean = true,
-            followLinks: Boolean = false,
-            maxDepth: Int = Int.MaxValue,
-            includeTarget: Boolean = false): IndexedSeq[Path] = {
+   * @param path the root path whose contents you wish to walk
+   *
+   * @param skip Skip certain files or folders from appearing in the output.
+   *             If you skip a folder, its entire subtree is ignored
+   *
+   * @param preOrder Whether you want a folder to appear before or after its
+   *                 contents in the final sequence. e.g. if you're deleting
+   *                 them recursively you want it to be false so the folder
+   *                 gets deleted last, but if you're copying them recursively
+   *                 you want `preOrder` to be `true` so the folder gets
+   *                 created first.
+   *
+   * @param followLinks Whether or not to follow symlinks while walking; defaults
+   *                    to false
+   *
+   * @param maxDepth The max depth of the tree you wish to walk; defaults to unlimited
+   *
+   * @param includeTarget Whether or not to include the given path as part of the walk.
+   *                      If `true`, does not raise an error if the given path is a
+   *                      simple file and not a folder
+   */
+  def apply(
+      path: Path,
+      skip: Path => Boolean = _ => false,
+      preOrder: Boolean = true,
+      followLinks: Boolean = false,
+      maxDepth: Int = Int.MaxValue,
+      includeTarget: Boolean = false
+  ): IndexedSeq[Path] = {
     stream(path, skip, preOrder, followLinks, maxDepth, includeTarget).toArray[Path].toIndexedSeq
   }
 
   /**
-    * @param path the root path whose contents you wish to walk
-    *
-    * @param skip Skip certain files or folders from appearing in the output.
-    *             If you skip a folder, its entire subtree is ignored
-    *
-    * @param preOrder Whether you want a folder to appear before or after its
-    *                 contents in the final sequence. e.g. if you're deleting
-    *                 them recursively you want it to be false so the folder
-    *                 gets deleted last, but if you're copying them recursively
-    *                 you want `preOrder` to be `true` so the folder gets
-    *                 created first.
-    *
-    * @param followLinks Whether or not to follow symlinks while walking; defaults
-    *                    to false
-    *
-    * @param maxDepth The max depth of the tree you wish to walk; defaults to unlimited
-    *
-    * @param includeTarget Whether or not to include the given path as part of the walk.
-    *                      If `true`, does not raise an error if the given path is a
-    *                      simple file and not a folder
-    */
-  def attrs(path: Path,
-            skip: (Path, os.StatInfo) => Boolean = (_, _) => false,
-            preOrder: Boolean = true,
-            followLinks: Boolean = false,
-            maxDepth: Int = Int.MaxValue,
-            includeTarget: Boolean = false): IndexedSeq[(Path, os.StatInfo)] = {
+   * @param path the root path whose contents you wish to walk
+   *
+   * @param skip Skip certain files or folders from appearing in the output.
+   *             If you skip a folder, its entire subtree is ignored
+   *
+   * @param preOrder Whether you want a folder to appear before or after its
+   *                 contents in the final sequence. e.g. if you're deleting
+   *                 them recursively you want it to be false so the folder
+   *                 gets deleted last, but if you're copying them recursively
+   *                 you want `preOrder` to be `true` so the folder gets
+   *                 created first.
+   *
+   * @param followLinks Whether or not to follow symlinks while walking; defaults
+   *                    to false
+   *
+   * @param maxDepth The max depth of the tree you wish to walk; defaults to unlimited
+   *
+   * @param includeTarget Whether or not to include the given path as part of the walk.
+   *                      If `true`, does not raise an error if the given path is a
+   *                      simple file and not a folder
+   */
+  def attrs(
+      path: Path,
+      skip: (Path, os.StatInfo) => Boolean = (_, _) => false,
+      preOrder: Boolean = true,
+      followLinks: Boolean = false,
+      maxDepth: Int = Int.MaxValue,
+      includeTarget: Boolean = false
+  ): IndexedSeq[(Path, os.StatInfo)] = {
     stream.attrs(path, skip, preOrder, followLinks, maxDepth, includeTarget)
       .toArray[(Path, os.StatInfo)].toIndexedSeq
   }
@@ -128,78 +133,82 @@ object walk {
   object stream {
 
     /**
-      * @param path the root path whose contents you wish to walk
-      *
-      * @param skip Skip certain files or folders from appearing in the output.
-      *             If you skip a folder, its entire subtree is ignored
-      *
-      * @param preOrder Whether you want a folder to appear before or after its
-      *                 contents in the final sequence. e.g. if you're deleting
-      *                 them recursively you want it to be false so the folder
-      *                 gets deleted last, but if you're copying them recursively
-      *                 you want `preOrder` to be `true` so the folder gets
-      *                 created first.
-      *
-      * @param followLinks Whether or not to follow symlinks while walking; defaults
-      *                    to false
-      *
-      * @param maxDepth The max depth of the tree you wish to walk; defaults to unlimited
-      *
-      * @param includeTarget Whether or not to include the given path as part of the walk.
-      *                      If `true`, does not raise an error if the given path is a
-      *                      simple file and not a folder
-      */
-    def apply(path: Path,
-              skip: Path => Boolean = _ => false,
-              preOrder: Boolean = true,
-              followLinks: Boolean = false,
-              maxDepth: Int = Int.MaxValue,
-              includeTarget: Boolean = false): Generator[Path] = {
+     * @param path the root path whose contents you wish to walk
+     *
+     * @param skip Skip certain files or folders from appearing in the output.
+     *             If you skip a folder, its entire subtree is ignored
+     *
+     * @param preOrder Whether you want a folder to appear before or after its
+     *                 contents in the final sequence. e.g. if you're deleting
+     *                 them recursively you want it to be false so the folder
+     *                 gets deleted last, but if you're copying them recursively
+     *                 you want `preOrder` to be `true` so the folder gets
+     *                 created first.
+     *
+     * @param followLinks Whether or not to follow symlinks while walking; defaults
+     *                    to false
+     *
+     * @param maxDepth The max depth of the tree you wish to walk; defaults to unlimited
+     *
+     * @param includeTarget Whether or not to include the given path as part of the walk.
+     *                      If `true`, does not raise an error if the given path is a
+     *                      simple file and not a folder
+     */
+    def apply(
+        path: Path,
+        skip: Path => Boolean = _ => false,
+        preOrder: Boolean = true,
+        followLinks: Boolean = false,
+        maxDepth: Int = Int.MaxValue,
+        includeTarget: Boolean = false
+    ): Generator[Path] = {
 
       attrs(path, (p, _) => skip(p), preOrder, followLinks, maxDepth, includeTarget).map(_._1)
     }
 
     /**
-      * @param path the root path whose contents you wish to walk
-      *
-      * @param skip Skip certain files or folders from appearing in the output.
-      *             If you skip a folder, its entire subtree is ignored
-      *
-      * @param preOrder Whether you want a folder to appear before or after its
-      *                 contents in the final sequence. e.g. if you're deleting
-      *                 them recursively you want it to be false so the folder
-      *                 gets deleted last, but if you're copying them recursively
-      *                 you want `preOrder` to be `true` so the folder gets
-      *                 created first.
-      *
-      * @param followLinks Whether or not to follow symlinks while walking; defaults
-      *                    to false
-      *
-      * @param maxDepth The max depth of the tree you wish to walk; defaults to unlimited
-      *
-      * @param includeTarget Whether or not to include the given path as part of the walk.
-      *                      If `true`, does not raise an error if the given path is a
-      *                      simple file and not a folder
-      */
-    def attrs(path: Path,
-              skip: (Path, os.StatInfo) => Boolean = (_, _) => false,
-              preOrder: Boolean = true,
-              followLinks: Boolean = false,
-              maxDepth: Int = Int.MaxValue,
-              includeTarget: Boolean = false): Generator[(Path, os.StatInfo)] = {
+     * @param path the root path whose contents you wish to walk
+     *
+     * @param skip Skip certain files or folders from appearing in the output.
+     *             If you skip a folder, its entire subtree is ignored
+     *
+     * @param preOrder Whether you want a folder to appear before or after its
+     *                 contents in the final sequence. e.g. if you're deleting
+     *                 them recursively you want it to be false so the folder
+     *                 gets deleted last, but if you're copying them recursively
+     *                 you want `preOrder` to be `true` so the folder gets
+     *                 created first.
+     *
+     * @param followLinks Whether or not to follow symlinks while walking; defaults
+     *                    to false
+     *
+     * @param maxDepth The max depth of the tree you wish to walk; defaults to unlimited
+     *
+     * @param includeTarget Whether or not to include the given path as part of the walk.
+     *                      If `true`, does not raise an error if the given path is a
+     *                      simple file and not a folder
+     */
+    def attrs(
+        path: Path,
+        skip: (Path, os.StatInfo) => Boolean = (_, _) => false,
+        preOrder: Boolean = true,
+        followLinks: Boolean = false,
+        maxDepth: Int = Int.MaxValue,
+        includeTarget: Boolean = false
+    ): Generator[(Path, os.StatInfo)] = {
 
       val opts0 = if (followLinks) Array[LinkOption]() else Array(LinkOption.NOFOLLOW_LINKS)
       val opts = new java.util.HashSet[FileVisitOption]
       if (followLinks) opts.add(FileVisitOption.FOLLOW_LINKS)
       val pathNIO = path.wrapped
-      if (!Files.exists(pathNIO, opts0:_*)){
+      if (!Files.exists(pathNIO, opts0: _*)) {
         throw new java.nio.file.NoSuchFileException(pathNIO.toString)
       }
-      new geny.Generator[(Path, os.StatInfo)]{
+      new geny.Generator[(Path, os.StatInfo)] {
         def generate(handleItem: ((Path, os.StatInfo)) => Generator.Action) = {
           var currentAction: geny.Generator.Action = geny.Generator.Continue
           val attrsStack = collection.mutable.Buffer.empty[os.StatInfo]
-          def actionToResult(action: Generator.Action) = action match{
+          def actionToResult(action: Generator.Action) = action match {
             case Generator.Continue => FileVisitResult.CONTINUE
             case Generator.End =>
               currentAction = Generator.End
@@ -260,8 +269,7 @@ object walk {
                         val dirP = Path(dir.toAbsolutePath)
                         if (dirP != path) {
                           handleItem((dirP, attrsStack.remove(attrsStack.length - 1)))
-                        }
-                        else currentAction
+                        } else currentAction
                       }
                     )
                   }

--- a/os/src/Model.scala
+++ b/os/src/Model.scala
@@ -9,16 +9,16 @@ import scala.language.implicitConversions
 import scala.util.Try
 
 /**
-  * Simple enum with the possible filesystem objects a path can resolve to
-  */
+ * Simple enum with the possible filesystem objects a path can resolve to
+ */
 sealed trait FileType
-object FileType{
+object FileType {
   case object File extends FileType
   case object Dir extends FileType
   case object SymLink extends FileType
   case object Other extends FileType
 }
-object PermSet{
+object PermSet {
   implicit def fromSet(value: java.util.Set[PosixFilePermission]): PermSet = {
     var total = 0
     import PosixFilePermission._
@@ -39,8 +39,8 @@ object PermSet{
   }
 
   /**
-    * Parses a `rwx-wxr-w` string into a [[PermSet]]
-    */
+   * Parses a `rwx-wxr-w` string into a [[PermSet]]
+   */
   implicit def fromString(arg: String): PermSet = {
     require(
       arg.length == 9,
@@ -51,7 +51,7 @@ object PermSet{
     def add(perm: PosixFilePermission) = {
       val i = permToOffset(perm)
       val expected = permToChar(perm)
-      if(arg(i) == expected) perms |= permToMask(perm)
+      if (arg(i) == expected) perms |= permToMask(perm)
       else if (arg(i) != '-') {
         throw new Exception(
           "Invalid permissions string: unknown character [" + arg(i) + "] " +
@@ -72,12 +72,12 @@ object PermSet{
   }
 
   /**
-    * Parses a 0x777 integer into a [[PermSet]]
-    */
+   * Parses a 0x777 integer into a [[PermSet]]
+   */
   implicit def fromInt(value: Int): PermSet = new PermSet(value)
 
   def permToMask(elem: PosixFilePermission) = 256 >> permToOffset(elem)
-  def permToChar(elem: PosixFilePermission) = elem match{
+  def permToChar(elem: PosixFilePermission) = elem match {
     case PosixFilePermission.OWNER_READ => 'r'
     case PosixFilePermission.OWNER_WRITE => 'w'
     case PosixFilePermission.OWNER_EXECUTE => 'x'
@@ -88,7 +88,7 @@ object PermSet{
     case PosixFilePermission.OTHERS_WRITE => 'w'
     case PosixFilePermission.OTHERS_EXECUTE => 'x'
   }
-  def permToOffset(elem: PosixFilePermission) = elem match{
+  def permToOffset(elem: PosixFilePermission) = elem match {
     case PosixFilePermission.OWNER_READ => 0
     case PosixFilePermission.OWNER_WRITE => 1
     case PosixFilePermission.OWNER_EXECUTE => 2
@@ -102,10 +102,10 @@ object PermSet{
 }
 
 /**
-  * A set of permissions; can be converted easily to the rw-rwx-r-x form via
-  * [[toString]], or to a set of [[PosixFilePermission]]s via [[toSet]] and the
-  * other way via `PermSet.fromString`/`PermSet.fromSet`
-  */
+ * A set of permissions; can be converted easily to the rw-rwx-r-x form via
+ * [[toString]], or to a set of [[PosixFilePermission]]s via [[toSet]] and the
+ * other way via `PermSet.fromString`/`PermSet.fromSet`
+ */
 case class PermSet(value: Int) {
   def contains(elem: PosixFilePermission) = (PermSet.permToMask(elem) & value) != 0
   def +(elem: PosixFilePermission) = new PermSet(value | PermSet.permToMask(elem))
@@ -120,7 +120,7 @@ case class PermSet(value: Int) {
     import PosixFilePermission._
     val perms = new java.util.HashSet[PosixFilePermission]()
     def add(perm: PosixFilePermission) = {
-      if((value & PermSet.permToMask(perm)) != 0) perms.add(perm)
+      if ((value & PermSet.permToMask(perm)) != 0) perms.add(perm)
     }
     add(OWNER_READ)
     add(OWNER_WRITE)
@@ -137,7 +137,7 @@ case class PermSet(value: Int) {
   override def toString() = {
     import PosixFilePermission._
     def add(perm: PosixFilePermission) = {
-      val c = PermSet. permToChar(perm)
+      val c = PermSet.permToChar(perm)
       if ((PermSet.permToMask(perm) & value) != 0) c else '-'
     }
     new String(
@@ -157,28 +157,31 @@ case class PermSet(value: Int) {
 }
 
 /**
-  * Contains the accumulated output for the invocation of a subprocess command.
-  *
-  * Apart from the exit code, the primary data-structure is a sequence of byte
-  * chunks, tagged with [[Left]] for stdout and [[Right]] for stderr. This is
-  * interleaved roughly in the order it was emitted by the subprocess, and
-  * reflects what a user would have see if the subprocess was run manually.
-  *
-  * Derived from that, is the aggregate `out` and `err` [[StreamValue]]s,
-  * wrapping stdout/stderr respectively, and providing convenient access to
-  * the aggregate output of each stream, as bytes or strings or lines.
-  */
-case class CommandResult(command: Seq[String],
-                         exitCode: Int,
-                         chunks: Seq[Either[geny.Bytes, geny.Bytes]]) {
+ * Contains the accumulated output for the invocation of a subprocess command.
+ *
+ * Apart from the exit code, the primary data-structure is a sequence of byte
+ * chunks, tagged with [[Left]] for stdout and [[Right]] for stderr. This is
+ * interleaved roughly in the order it was emitted by the subprocess, and
+ * reflects what a user would have see if the subprocess was run manually.
+ *
+ * Derived from that, is the aggregate `out` and `err` [[StreamValue]]s,
+ * wrapping stdout/stderr respectively, and providing convenient access to
+ * the aggregate output of each stream, as bytes or strings or lines.
+ */
+case class CommandResult(
+    command: Seq[String],
+    exitCode: Int,
+    chunks: Seq[Either[geny.Bytes, geny.Bytes]]
+) {
+
   /**
-    * The standard output and error of the executed command, exposed in a
-    * number of ways for convenient access
-    */
+   * The standard output and error of the executed command, exposed in a
+   * number of ways for convenient access
+   */
   val (out, err) = {
     val outChunks = collection.mutable.Buffer.empty[geny.Bytes]
     val errChunks = collection.mutable.Buffer.empty[geny.Bytes]
-    chunks.foreach{
+    chunks.foreach {
       case Left(s) => outChunks.append(s)
       case Right(s) => errChunks.append(s)
     }
@@ -189,27 +192,30 @@ case class CommandResult(command: Seq[String],
     val denoteMoreCommandChunks = if (command.length == 1) "" else "…"
     s"Result of ${command.head}${denoteMoreCommandChunks}: $exitCode\n" +
       chunks.iterator
-        .collect{case Left(s) => s case Right(s) => s}
+        .collect {
+          case Left(s) => s
+          case Right(s) => s
+        }
         .map(x => new String(x.array))
         .mkString
   }
 }
 
 /**
-  * Thrown when a shellout command results in a non-zero exit code.
-  *
-  * Doesn't contain any additional information apart from the [[CommandResult]]
-  * that is normally returned, but ensures that failures in subprocesses happen
-  * loudly and won't get ignored unless intentionally caught
-  */
+ * Thrown when a shellout command results in a non-zero exit code.
+ *
+ * Doesn't contain any additional information apart from the [[CommandResult]]
+ * that is normally returned, but ensures that failures in subprocesses happen
+ * loudly and won't get ignored unless intentionally caught
+ */
 case class SubprocessException(result: CommandResult) extends Exception(result.toString)
 
 /**
-  * An implicit wrapper defining the things that can
-  * be "interpolated" directly into a subprocess call.
-  */
+ * An implicit wrapper defining the things that can
+ * be "interpolated" directly into a subprocess call.
+ */
 case class Shellable(value: Seq[String])
-object Shellable{
+object Shellable {
   implicit def StringShellable(s: String): Shellable = Shellable(Seq(s))
   implicit def CharSequenceShellable(cs: CharSequence): Shellable = Shellable(Seq(cs.toString))
 
@@ -226,25 +232,27 @@ object Shellable{
 }
 
 /**
-  * The result from doing an system `stat` on a particular path.
-  *
-  * Note: ctime is not same as ctime (Change Time) in `stat`,
-  *       it is creation time maybe fall back to mtime if system not supported it.
-  *
-  * Created via `stat! filePath`.
-  *
-  * If you want more information, use `stat.full`
-  */
-case class StatInfo(size: Long,
-                    mtime: FileTime,
-                    ctime: FileTime,
-                    atime: FileTime,
-                    fileType: FileType){
+ * The result from doing an system `stat` on a particular path.
+ *
+ * Note: ctime is not same as ctime (Change Time) in `stat`,
+ *       it is creation time maybe fall back to mtime if system not supported it.
+ *
+ * Created via `stat! filePath`.
+ *
+ * If you want more information, use `stat.full`
+ */
+case class StatInfo(
+    size: Long,
+    mtime: FileTime,
+    ctime: FileTime,
+    atime: FileTime,
+    fileType: FileType
+) {
   def isDir = fileType == FileType.Dir
   def isSymLink = fileType == FileType.SymLink
   def isFile = fileType == FileType.File
 }
-object StatInfo{
+object StatInfo {
 
   def make(attrs: BasicFileAttributes) = {
     new StatInfo(
@@ -262,7 +270,7 @@ object StatInfo{
 }
 
 case class PosixStatInfo(owner: UserPrincipal, permissions: PermSet)
-object PosixStatInfo{
+object PosixStatInfo {
   def make(posixAttrs: PosixFileAttributes) = {
     PosixStatInfo(
       posixAttrs.owner,

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -3,11 +3,11 @@ package os
 import collection.JavaConverters._
 import scala.language.implicitConversions
 
-trait PathChunk{
+trait PathChunk {
   def segments: Seq[String]
   def ups: Int
 }
-object PathChunk{
+object PathChunk {
   implicit class RelPathChunk(r: RelPath) extends PathChunk {
     def segments = r.segments
     def ups = r.ups
@@ -40,78 +40,79 @@ object PathChunk{
   implicit class SeqPathChunk[T](a: Seq[T])(implicit f: T => PathChunk) extends PathChunk {
     var segments0 = Nil
     var ups0 = 0
-    val (segments, ups) = a.map(f).foldLeft((Seq[String](), 0)){ case ((segments, ups), chunk) =>
-      (segments.dropRight(chunk.ups) ++ chunk.segments,
-      math.max(chunk.ups - segments.length, 0))
+    val (segments, ups) = a.map(f).foldLeft((Seq[String](), 0)) { case ((segments, ups), chunk) =>
+      (segments.dropRight(chunk.ups) ++ chunk.segments, math.max(chunk.ups - segments.length, 0))
     }
 
     override def toString() = segments.mkString("/")
   }
 }
+
 /**
-  * A path which is either an absolute [[Path]], a relative [[RelPath]],
-  * or a [[ResourcePath]] with shared APIs and implementations.
-  *
-  * Most of the filesystem-independent path-manipulation logic that lets you
-  * splice paths together or navigate in and out of paths lives in this interface
-  */
-trait BasePath{
+ * A path which is either an absolute [[Path]], a relative [[RelPath]],
+ * or a [[ResourcePath]] with shared APIs and implementations.
+ *
+ * Most of the filesystem-independent path-manipulation logic that lets you
+ * splice paths together or navigate in and out of paths lives in this interface
+ */
+trait BasePath {
   type ThisType <: BasePath
+
   /**
-    * Combines this path with the given relative path, returning
-    * a path of the same type as this one (e.g. `Path` returns `Path`,
-    * `RelPath` returns `RelPath`
-    */
+   * Combines this path with the given relative path, returning
+   * a path of the same type as this one (e.g. `Path` returns `Path`,
+   * `RelPath` returns `RelPath`
+   */
   def /(chunk: PathChunk): ThisType
 
   /**
-    * Relativizes this path with the given `target` path, finding a
-    * relative path `p` such that base/p == this.
-    *
-    * Note that you can only relativize paths of the same type, e.g.
-    * `Path` & `Path` or `RelPath` & `RelPath`. In the case of `RelPath`,
-    * this can throw a [[PathError.NoRelativePath]] if there is no
-    * relative path that satisfies the above requirement in the general
-    * case.
-    */
+   * Relativizes this path with the given `target` path, finding a
+   * relative path `p` such that base/p == this.
+   *
+   * Note that you can only relativize paths of the same type, e.g.
+   * `Path` & `Path` or `RelPath` & `RelPath`. In the case of `RelPath`,
+   * this can throw a [[PathError.NoRelativePath]] if there is no
+   * relative path that satisfies the above requirement in the general
+   * case.
+   */
   def relativeTo(target: ThisType): RelPath
 
   /**
-    * Relativizes this path with the given `target` path, finding a
-    * sub path `p` such that base/p == this.
-    */
+   * Relativizes this path with the given `target` path, finding a
+   * sub path `p` such that base/p == this.
+   */
   def subRelativeTo(target: ThisType): SubPath = relativeTo(target).asSubPath
 
   /**
-    * This path starts with the target path, including if it's identical
-    */
+   * This path starts with the target path, including if it's identical
+   */
   def startsWith(target: ThisType): Boolean
 
   /**
-    * This path ends with the target path, including if it's identical
-    */
+   * This path ends with the target path, including if it's identical
+   */
   def endsWith(target: RelPath): Boolean
 
   /**
-    * The last segment in this path. Very commonly used, e.g. it
-    * represents the name of the file/folder in filesystem paths
-    */
+   * The last segment in this path. Very commonly used, e.g. it
+   * represents the name of the file/folder in filesystem paths
+   */
   def last: String
 
   /**
-    * Gives you the file extension of this path, or the empty
-    * string if there is no extension
-    */
+   * Gives you the file extension of this path, or the empty
+   * string if there is no extension
+   */
   def ext: String
 
   /**
-    * Gives you the base name of this path, ie without the extension
-    */
+   * Gives you the base name of this path, ie without the extension
+   */
   def baseName: String
 
   /**
-    * The individual path segments of this path.
-    */
+   * The individual path segments of this path.
+   */
   def segments: TraversableOnce[String]
 
 }
@@ -122,18 +123,18 @@ object BasePath {
     def considerStr =
       "use the Path(...) or RelPath(...) constructor calls to convert them. "
 
-    s.indexOf('/') match{
+    s.indexOf('/') match {
       case -1 => // do nothing
       case c => fail(
-        s"[/] is not a valid character to appear in a path segment. " +
-          "If you want to parse an absolute or relative path that may have " +
-          "multiple segments, e.g. path-strings coming from external sources " +
-          considerStr
-      )
+          s"[/] is not a valid character to appear in a path segment. " +
+            "If you want to parse an absolute or relative path that may have " +
+            "multiple segments, e.g. path-strings coming from external sources " +
+            considerStr
+        )
 
     }
     def externalStr = "If you are dealing with path-strings coming from external sources, "
-    s match{
+    s match {
       case "" =>
         fail(
           "OS-Lib does not allow empty path segments " +
@@ -162,11 +163,12 @@ object BasePath {
   }
 }
 
-trait SegmentedPath extends BasePath{
+trait SegmentedPath extends BasePath {
   protected[this] def make(p: Seq[String], ups: Int): ThisType
+
   /**
-    * The individual path segments of this path.
-    */
+   * The individual path segments of this path.
+   */
   def segments: IndexedSeq[String]
 
   def /(chunk: PathChunk) = make(
@@ -179,16 +181,16 @@ trait SegmentedPath extends BasePath{
   }
 }
 
-trait BasePathImpl extends BasePath{
+trait BasePathImpl extends BasePath {
   def /(chunk: PathChunk): ThisType
 
   def ext = {
-    lastOpt match{
+    lastOpt match {
       case None => ""
       case Some(lastSegment) =>
         val li = lastSegment.lastIndexOf('.')
         if (li == -1) ""
-        else last.slice(li+1, last.length)
+        else last.slice(li + 1, last.length)
     }
 
   }
@@ -204,7 +206,7 @@ trait BasePathImpl extends BasePath{
   def lastOpt: Option[String]
 }
 
-object PathError{
+object PathError {
   type IAE = IllegalArgumentException
   private[this] def errorMsg(s: String, msg: String) =
     s"[$s] is not a valid path segment. $msg"
@@ -212,21 +214,21 @@ object PathError{
   case class InvalidSegment(segment: String, msg: String) extends IAE(errorMsg(segment, msg))
 
   case object AbsolutePathOutsideRoot
-    extends IAE("The path created has enough ..s that it would start outside the root directory")
+      extends IAE("The path created has enough ..s that it would start outside the root directory")
 
   case class NoRelativePath(src: RelPath, base: RelPath)
-    extends IAE(s"Can't relativize relative paths $src from $base")
+      extends IAE(s"Can't relativize relative paths $src from $base")
 
   case class LastOnEmptyPath()
-    extends IAE("empty path has no last segment")
+      extends IAE("empty path has no last segment")
 }
 
 /**
-  * Represents a value that is either an absolute [[Path]] or a
-  * relative [[RelPath]], and can be constructed from a
-  * java.nio.file.Path or java.io.File
-  */
-sealed trait FilePath extends BasePath{
+ * Represents a value that is either an absolute [[Path]] or a
+ * relative [[RelPath]], and can be constructed from a
+ * java.nio.file.Path or java.io.File
+ */
+sealed trait FilePath extends BasePath {
   def toNIO: java.nio.file.Path
   def resolveFrom(base: os.Path): os.Path
 }
@@ -243,13 +245,13 @@ object FilePath {
 }
 
 /**
-  * A relative path on the filesystem. Note that the path is
-  * normalized and cannot contain any empty or ".". Parent ".."
-  * segments can only occur at the left-end of the path, and
-  * are collapsed into a single number [[ups]].
-  */
-class RelPath private[os](segments0: Array[String], val ups: Int)
-  extends FilePath with BasePathImpl with SegmentedPath {
+ * A relative path on the filesystem. Note that the path is
+ * normalized and cannot contain any empty or ".". Parent ".."
+ * segments can only occur at the left-end of the path, and
+ * are collapsed into a single number [[ups]].
+ */
+class RelPath private[os] (segments0: Array[String], val ups: Int)
+    extends FilePath with BasePathImpl with SegmentedPath {
   def lastOpt = segments.lastOption
   val segments: IndexedSeq[String] = segments0.toIndexedSeq
   type ThisType = RelPath
@@ -312,10 +314,10 @@ object RelPath {
 }
 
 /**
-  * A relative path on the filesystem, without any `..` or `.` segments
-  */
-class SubPath private[os](val segments0: Array[String])
-  extends FilePath with BasePathImpl with SegmentedPath {
+ * A relative path on the filesystem, without any `..` or `.` segments
+ */
+class SubPath private[os] (val segments0: Array[String])
+    extends FilePath with BasePathImpl with SegmentedPath {
   def lastOpt = segments.lastOption
   val segments: IndexedSeq[String] = segments0.toIndexedSeq
   type ThisType = SubPath
@@ -348,7 +350,7 @@ object SubPath {
     val commonPrefix = {
       val maxSize = scala.math.min(segments0.length, segments.length)
       var i = 0
-      while ( i < maxSize && segments0(i) == segments(i)) i += 1
+      while (i < maxSize && segments0(i) == segments(i)) i += 1
       i
     }
     val newUps = segments.length - commonPrefix
@@ -370,21 +372,21 @@ object SubPath {
 }
 
 object Path {
-  def apply(p: FilePath, base: Path) = p match{
+  def apply(p: FilePath, base: Path) = p match {
     case p: RelPath => base / p
     case p: SubPath => base / p
     case p: Path => p
   }
 
   /**
-    * Equivalent to [[os.Path.apply]], but automatically expands a
-    * leading `~/` into the user's home directory, for convenience
-    */
+   * Equivalent to [[os.Path.apply]], but automatically expands a
+   * leading `~/` into the user's home directory, for convenience
+   */
   def expandUser[T: PathConvertible](f0: T, base: Path = null) = {
     val f = implicitly[PathConvertible[T]].apply(f0)
     if (f.subpath(0, 1).toString != "~") if (base == null) Path(f0) else Path(f0, base)
     else {
-      Path(System.getProperty("user.home"))(PathConvertible.StringConvertible)/
+      Path(System.getProperty("user.home"))(PathConvertible.StringConvertible) /
         RelPath(f.subpath(0, 1).relativize(f))(PathConvertible.NioPathConvertible)
     }
   }
@@ -392,7 +394,7 @@ object Path {
   def apply[T: PathConvertible](f: T, base: Path): Path = apply(FilePath(f), base)
   def apply[T: PathConvertible](f0: T): Path = {
     val f = implicitly[PathConvertible[T]].apply(f0)
-    if (f.iterator.asScala.count(_.startsWith("..")) > f.getNameCount/ 2) {
+    if (f.iterator.asScala.count(_.startsWith("..")) > f.getNameCount / 2) {
       throw PathError.AbsolutePathOutsideRoot
     }
 
@@ -400,14 +402,14 @@ object Path {
     new Path(normalized)
   }
 
-  implicit val pathOrdering: Ordering[Path] = new Ordering[Path]{
+  implicit val pathOrdering: Ordering[Path] = new Ordering[Path] {
     def compare(x: Path, y: Path): Int = {
       val xSegCount = x.segmentCount
       val ySegCount = y.segmentCount
       if (xSegCount < ySegCount) -1
       else if (xSegCount > ySegCount) 1
       else if (xSegCount == 0 && ySegCount == 0) 0
-      else{
+      else {
         var xSeg = ""
         var ySeg = ""
         var i = 0
@@ -431,17 +433,17 @@ object Path {
 
 }
 
-trait ReadablePath{
+trait ReadablePath {
   def toSource: os.Source
   def getInputStream: java.io.InputStream
 }
 
 /**
-  * An absolute path on the filesystem. Note that the path is
-  * normalized and cannot contain any empty `""`, `"."` or `".."` segments
-  */
-class Path private[os](val wrapped: java.nio.file.Path)
-  extends FilePath with ReadablePath with BasePathImpl {
+ * An absolute path on the filesystem. Note that the path is
+ * normalized and cannot contain any empty `""`, `"."` or `".."` segments
+ */
+class Path private[os] (val wrapped: java.nio.file.Path)
+    extends FilePath with ReadablePath with BasePathImpl {
   def toSource: SeekableSource =
     new SeekableSource.ChannelSource(java.nio.file.Files.newByteChannel(wrapped))
 
@@ -473,11 +475,11 @@ class Path private[os](val wrapped: java.nio.file.Path)
   def relativeTo(base: Path): RelPath = {
 
     val nioRel = base.wrapped.relativize(wrapped)
-    val segments = nioRel.iterator().asScala.map(_.toString).toArray match{
+    val segments = nioRel.iterator().asScala.map(_.toString).toArray match {
       case Array("") => Internals.emptyStringArray
       case arr => arr
     }
-    val nonUpIndex = segments.indexWhere(_ != "..") match{
+    val nonUpIndex = segments.indexWhere(_ != "..") match {
       case -1 => segments.length
       case n => n
     }
@@ -493,18 +495,18 @@ class Path private[os](val wrapped: java.nio.file.Path)
   def getInputStream = java.nio.file.Files.newInputStream(wrapped)
 }
 
-sealed trait PathConvertible[T]{
+sealed trait PathConvertible[T] {
   def apply(t: T): java.nio.file.Path
 }
 
-object PathConvertible{
-  implicit object StringConvertible extends PathConvertible[String]{
+object PathConvertible {
+  implicit object StringConvertible extends PathConvertible[String] {
     def apply(t: String) = java.nio.file.Paths.get(t)
   }
-  implicit object JavaIoFileConvertible extends PathConvertible[java.io.File]{
+  implicit object JavaIoFileConvertible extends PathConvertible[java.io.File] {
     def apply(t: java.io.File) = java.nio.file.Paths.get(t.getPath)
   }
-  implicit object NioPathConvertible extends PathConvertible[java.nio.file.Path]{
+  implicit object NioPathConvertible extends PathConvertible[java.nio.file.Path] {
     def apply(t: java.nio.file.Path) = t
   }
 }

--- a/os/src/PermsOps.scala
+++ b/os/src/PermsOps.scala
@@ -4,23 +4,24 @@ import java.nio.file.{Files, LinkOption}
 import java.nio.file.attribute.{GroupPrincipal, PosixFileAttributeView, UserPrincipal}
 
 /**
-  * Get the filesystem permissions of the file/folder at the given path
-  */
-object perms extends Function1[Path, PermSet]{
+ * Get the filesystem permissions of the file/folder at the given path
+ */
+object perms extends Function1[Path, PermSet] {
   def apply(p: Path): PermSet = apply(p, followLinks = true)
   def apply(p: Path, followLinks: Boolean = true): PermSet = {
     val opts = if (followLinks) Array[LinkOption]() else Array(LinkOption.NOFOLLOW_LINKS)
-    PermSet.fromSet(Files.getPosixFilePermissions(p.wrapped, opts:_*))
+    PermSet.fromSet(Files.getPosixFilePermissions(p.wrapped, opts: _*))
   }
+
   /**
-    * Set the filesystem permissions of the file/folder at the given path
-    *
-    * Note that if you want to create a file or folder with a given set of
-    * permissions, you can pass in an [[os.PermSet]] to [[os.write]]
-    * or [[os.makeDir]]. That will ensure the file or folder is created
-    * atomically with the given permissions, rather than being created with the
-    * default set of permissions and having `os.perms.set` over-write them later
-    */
+   * Set the filesystem permissions of the file/folder at the given path
+   *
+   * Note that if you want to create a file or folder with a given set of
+   * permissions, you can pass in an [[os.PermSet]] to [[os.write]]
+   * or [[os.makeDir]]. That will ensure the file or folder is created
+   * atomically with the given permissions, rather than being created with the
+   * default set of permissions and having `os.perms.set` over-write them later
+   */
   object set {
     def apply(p: Path, arg2: PermSet): Unit = {
       Files.setPosixFilePermissions(p.wrapped, arg2.toSet())
@@ -29,20 +30,19 @@ object perms extends Function1[Path, PermSet]{
 
 }
 
-
 /**
-  * Get the owner of the file/folder at the given path
-  */
+ * Get the owner of the file/folder at the given path
+ */
 object owner extends Function1[Path, UserPrincipal] {
   def apply(p: Path): UserPrincipal = apply(p, followLinks = true)
   def apply(p: Path, followLinks: Boolean = true): UserPrincipal = {
     val opts = if (followLinks) Array[LinkOption]() else Array(LinkOption.NOFOLLOW_LINKS)
-    Files.getOwner(p.wrapped, opts:_*)
+    Files.getOwner(p.wrapped, opts: _*)
   }
 
   /**
-    * Set the owner of the file/folder at the given path
-    */
+   * Set the owner of the file/folder at the given path
+   */
   object set {
     def apply(arg1: Path, arg2: UserPrincipal): Unit = Files.setOwner(arg1.wrapped, arg2)
     def apply(arg1: Path, arg2: String): Unit = {
@@ -54,10 +54,9 @@ object owner extends Function1[Path, UserPrincipal] {
   }
 }
 
-
 /**
-  * Get the owning group of the file/folder at the given path
-  */
+ * Get the owning group of the file/folder at the given path
+ */
 object group extends Function1[Path, GroupPrincipal] {
   def apply(p: Path): GroupPrincipal = apply(p, followLinks = true)
   def apply(p: Path, followLinks: Boolean = true): GroupPrincipal = {
@@ -65,13 +64,13 @@ object group extends Function1[Path, GroupPrincipal] {
     Files.getFileAttributeView(
       p.wrapped,
       classOf[PosixFileAttributeView],
-      opts:_*
+      opts: _*
     ).readAttributes().group()
   }
 
   /**
-    * Set the owning group of the file/folder at the given path
-    */
+   * Set the owning group of the file/folder at the given path
+   */
   object set {
     def apply(arg1: Path, arg2: GroupPrincipal): Unit = {
       Files.getFileAttributeView(

--- a/os/src/ReadWriteOps.scala
+++ b/os/src/ReadWriteOps.scala
@@ -10,43 +10,48 @@ import scala.io.Codec
 import StandardOpenOption.{CREATE, WRITE}
 
 /**
-  * Write some data to a file. This can be a String, an Array[Byte], or a
-  * Seq[String] which is treated as consecutive lines. By default, this
-  * fails if a file already exists at the target location. Use [[write.over]]
-  * or [[write.append]] if you want to over-write it or add to what's already
-  * there.
-  */
-object write{
+ * Write some data to a file. This can be a String, an Array[Byte], or a
+ * Seq[String] which is treated as consecutive lines. By default, this
+ * fails if a file already exists at the target location. Use [[write.over]]
+ * or [[write.append]] if you want to over-write it or add to what's already
+ * there.
+ */
+object write {
+
   /**
-    * Open a [[java.io.OutputStream]] to write to the given file
-    */
-  def outputStream(target: Path,
-                   perms: PermSet = null,
-                   createFolders: Boolean = false,
-                   openOptions: Seq[OpenOption] = Seq(CREATE, WRITE)) = {
-    if (createFolders) makeDir.all(target/RelPath.up, perms)
-    if (perms != null && !exists(target)){
+   * Open a [[java.io.OutputStream]] to write to the given file
+   */
+  def outputStream(
+      target: Path,
+      perms: PermSet = null,
+      createFolders: Boolean = false,
+      openOptions: Seq[OpenOption] = Seq(CREATE, WRITE)
+  ) = {
+    if (createFolders) makeDir.all(target / RelPath.up, perms)
+    if (perms != null && !exists(target)) {
       val permArray =
         if (perms == null) Array[FileAttribute[PosixFilePermission]]()
         else Array(PosixFilePermissions.asFileAttribute(perms.toSet()))
-      java.nio.file.Files.createFile(target.toNIO, permArray:_*)
+      java.nio.file.Files.createFile(target.toNIO, permArray: _*)
     }
     java.nio.file.Files.newOutputStream(
       target.toNIO,
-      openOptions.toArray:_*
+      openOptions.toArray: _*
     )
   }
 
   /**
-    * Performs the actual opening and writing to a file. Basically cribbed
-    * from `java.nio.file.Files.write` so we could re-use it properly for
-    * different combinations of flags and all sorts of [[Source]]s
-    */
-  def write(target: Path,
-            data: Source,
-            flags: Seq[StandardOpenOption],
-            perms: PermSet,
-            offset: Long) = {
+   * Performs the actual opening and writing to a file. Basically cribbed
+   * from `java.nio.file.Files.write` so we could re-use it properly for
+   * different combinations of flags and all sorts of [[Source]]s
+   */
+  def write(
+      target: Path,
+      data: Source,
+      flags: Seq[StandardOpenOption],
+      perms: PermSet,
+      offset: Long
+  ) = {
 
     import collection.JavaConverters._
     val permArray: Array[FileAttribute[_]] =
@@ -56,32 +61,37 @@ object write{
     val out = Files.newByteChannel(
       target.wrapped,
       flags.toSet.asJava,
-      permArray:_*
+      permArray: _*
     )
     out.position(offset)
     try data.writeBytesTo(out)
     finally if (out != null) out.close()
   }
-  def apply(target: Path,
-            data: Source,
-            perms: PermSet = null,
-            createFolders: Boolean = false): Unit = {
-    if (createFolders) makeDir.all(target/RelPath.up, perms)
+  def apply(
+      target: Path,
+      data: Source,
+      perms: PermSet = null,
+      createFolders: Boolean = false
+  ): Unit = {
+    if (createFolders) makeDir.all(target / RelPath.up, perms)
     write(target, data, Seq(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE), perms, 0)
   }
 
   /**
-    * Identical to [[write]], except if the file already exists,
-    * appends to the file instead of error-ing out
-    */
-  object append{
-    def apply(target: Path,
-              data: Source,
-              perms: PermSet = null,
-              createFolders: Boolean = false): Unit = {
-      if (createFolders) makeDir.all(target/RelPath.up, perms)
+   * Identical to [[write]], except if the file already exists,
+   * appends to the file instead of error-ing out
+   */
+  object append {
+    def apply(
+        target: Path,
+        data: Source,
+        perms: PermSet = null,
+        createFolders: Boolean = false
+    ): Unit = {
+      if (createFolders) makeDir.all(target / RelPath.up, perms)
       write(
-        target, data,
+        target,
+        data,
         Seq(StandardOpenOption.CREATE, StandardOpenOption.APPEND, StandardOpenOption.WRITE),
         perms,
         0
@@ -89,11 +99,9 @@ object write{
     }
 
     /**
-      * Open a [[java.io.OutputStream]] to write or append to the given file
-      */
-    def outputStream(target: Path,
-                     perms: PermSet = null,
-                     createFolders: Boolean = false) = {
+     * Open a [[java.io.OutputStream]] to write or append to the given file
+     */
+    def outputStream(target: Path, perms: PermSet = null, createFolders: Boolean = false) = {
       os.write.outputStream(
         target,
         perms,
@@ -106,22 +114,26 @@ object write{
       )
     }
   }
+
   /**
-    * Similar to [[os.write]], except if the file already exists this
-    * over-writes the existing file contents. You can also pass in `truncate = false`
-    * to avoid truncating the file if the new contents is shorter than the old
-    * contents, and an `offset` to the file you want to write to.
-    */
-  object over{
-    def apply(target: Path,
-              data: Source,
-              perms: PermSet = null,
-              offset: Long = 0,
-              createFolders: Boolean = false,
-              truncate: Boolean = true): Unit = {
-      if (createFolders) makeDir.all(target/RelPath.up, perms)
+   * Similar to [[os.write]], except if the file already exists this
+   * over-writes the existing file contents. You can also pass in `truncate = false`
+   * to avoid truncating the file if the new contents is shorter than the old
+   * contents, and an `offset` to the file you want to write to.
+   */
+  object over {
+    def apply(
+        target: Path,
+        data: Source,
+        perms: PermSet = null,
+        offset: Long = 0,
+        createFolders: Boolean = false,
+        truncate: Boolean = true
+    ): Unit = {
+      if (createFolders) makeDir.all(target / RelPath.up, perms)
       write(
-        target, data,
+        target,
+        data,
         Seq(
           StandardOpenOption.CREATE,
           StandardOpenOption.WRITE
@@ -132,11 +144,9 @@ object write{
     }
 
     /**
-      * Open a [[java.io.OutputStream]] to write to the given file
-      */
-    def outputStream(target: Path,
-                     perms: PermSet = null,
-                     createFolders: Boolean = false) = {
+     * Open a [[java.io.OutputStream]] to write to the given file
+     */
+    def outputStream(target: Path, perms: PermSet = null, createFolders: Boolean = false) = {
       os.write.outputStream(
         target,
         perms,
@@ -151,22 +161,23 @@ object write{
   }
 
   /**
-    * Opens a [[SeekableByteChannel]] to write to the given file.
-    */
-  object channel extends Function1[Path, SeekableByteChannel]{
+   * Opens a [[SeekableByteChannel]] to write to the given file.
+   */
+  object channel extends Function1[Path, SeekableByteChannel] {
     def write(p: Path, options: Seq[StandardOpenOption]) = {
-      java.nio.file.Files.newByteChannel(p.toNIO, options.toArray:_*)
+      java.nio.file.Files.newByteChannel(p.toNIO, options.toArray: _*)
     }
     def apply(p: Path): SeekableByteChannel = {
       write(p, Seq(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE))
     }
 
     /**
-      * Opens a [[SeekableByteChannel]] to write to the given file.
-      */
-    object append extends Function1[Path, SeekableByteChannel]{
+     * Opens a [[SeekableByteChannel]] to write to the given file.
+     */
+    object append extends Function1[Path, SeekableByteChannel] {
       def apply(p: Path): SeekableByteChannel = {
-        write(p,
+        write(
+          p,
           Seq(
             StandardOpenOption.CREATE,
             StandardOpenOption.APPEND,
@@ -175,12 +186,14 @@ object write{
         )
       }
     }
+
     /**
-      * Opens a [[SeekableByteChannel]] to write to the given file.
-      */
-    object over extends Function1[Path, SeekableByteChannel]{
+     * Opens a [[SeekableByteChannel]] to write to the given file.
+     */
+    object over extends Function1[Path, SeekableByteChannel] {
       def apply(p: Path): SeekableByteChannel = {
-        write(p,
+        write(
+          p,
           Seq(
             StandardOpenOption.CREATE,
             StandardOpenOption.TRUNCATE_EXISTING,
@@ -193,10 +206,10 @@ object write{
 }
 
 /**
-  * Truncate the given file to the given size. If the file is smaller than the
-  * given size, does nothing.
-  */
-object truncate{
+ * Truncate the given file to the given size. If the file is smaller than the
+ * given size, does nothing.
+ */
+object truncate {
   def apply(p: Path, size: Long): Unit = {
     val channel = FileChannel.open(p.toNIO, StandardOpenOption.WRITE)
     try channel.truncate(size)
@@ -205,52 +218,55 @@ object truncate{
 }
 
 /**
-  * Reads the contents of a [[os.Path]] or other [[os.Source]] as a
-  * `java.lang.String`. Defaults to reading the entire file as UTF-8, but you can
-  * also select a different `charSet` to use, and provide an `offset`/`count` to
-  * read from if the source supports seeking.
-  */
-object read extends Function1[ReadablePath, String]{
+ * Reads the contents of a [[os.Path]] or other [[os.Source]] as a
+ * `java.lang.String`. Defaults to reading the entire file as UTF-8, but you can
+ * also select a different `charSet` to use, and provide an `offset`/`count` to
+ * read from if the source supports seeking.
+ */
+object read extends Function1[ReadablePath, String] {
   def apply(arg: ReadablePath): String = apply(arg, java.nio.charset.StandardCharsets.UTF_8)
   def apply(arg: ReadablePath, charSet: Codec): String = {
     new String(read.bytes(arg), charSet.charSet)
   }
-  def apply(arg: Path,
-            charSet: Codec = java.nio.charset.StandardCharsets.UTF_8,
-            offset: Long = 0,
-            count: Int = Int.MaxValue): String = {
+  def apply(
+      arg: Path,
+      charSet: Codec = java.nio.charset.StandardCharsets.UTF_8,
+      offset: Long = 0,
+      count: Int = Int.MaxValue
+  ): String = {
     new String(read.bytes(arg, offset, count), charSet.charSet)
   }
 
   /**
-    * Opens a [[java.io.InputStream]] to read from the given file
-    */
-  object inputStream extends Function1[ReadablePath, java.io.InputStream]{
+   * Opens a [[java.io.InputStream]] to read from the given file
+   */
+  object inputStream extends Function1[ReadablePath, java.io.InputStream] {
     def apply(p: ReadablePath): java.io.InputStream = p.getInputStream
   }
 
-  object stream extends Function1[ReadablePath, geny.Readable]{
-    def apply(p: ReadablePath): geny.Readable = new geny.Readable{
+  object stream extends Function1[ReadablePath, geny.Readable] {
+    def apply(p: ReadablePath): geny.Readable = new geny.Readable {
       def readBytesThrough[T](f: java.io.InputStream => T): T = {
         val is = p.getInputStream
-        try f(is) finally is.close()
+        try f(is)
+        finally is.close()
       }
     }
   }
 
   /**
-    * Opens a [[SeekableByteChannel]] to read from the given file.
-    */
-  object channel extends Function1[Path, SeekableByteChannel]{
+   * Opens a [[SeekableByteChannel]] to read from the given file.
+   */
+  object channel extends Function1[Path, SeekableByteChannel] {
     def apply(p: Path): SeekableByteChannel = p.toSource.getChannel()
   }
 
   /**
-    * Reads the contents of a [[os.Path]] or [[os.Source]] as an
-    * `Array[Byte]`; you can provide an `offset`/`count` to read from if the source
-    * supports seeking.
-    */
-  object bytes extends Function1[ReadablePath, Array[Byte]]{
+   * Reads the contents of a [[os.Path]] or [[os.Source]] as an
+   * `Array[Byte]`; you can provide an `offset`/`count` to read from if the source
+   * supports seeking.
+   */
+  object bytes extends Function1[ReadablePath, Array[Byte]] {
     def apply(arg: ReadablePath): Array[Byte] = {
       val out = new java.io.ByteArrayOutputStream()
       val stream = arg.getInputStream
@@ -262,30 +278,30 @@ object read extends Function1[ReadablePath, String]{
       val arr = new Array[Byte](count)
       val buf = ByteBuffer.wrap(arr)
       val channel = arg.toSource.getChannel()
-      try{
+      try {
         channel.position(offset)
         val finalCount = channel.read(buf)
         if (finalCount == arr.length) arr
         else arr.take(finalCount)
-      } finally{
+      } finally {
         channel.close()
       }
     }
   }
 
   /**
-    * Reads the contents of the given [[os.Path]] in chunks of the given size;
-    * returns a generator which provides a byte array and an offset into that
-    * array which contains the data for that chunk. All chunks will be of the
-    * given size, except for the last chunk which may be smaller.
-    *
-    * Note that the array returned by the generator is shared between each
-    * callback; make sure you copy the bytes/array somewhere else if you want
-    * to keep them around.
-    *
-    * Optionally takes in a provided input `buffer` instead of a `chunkSize`,
-    * allowing you to re-use the buffer between invocations.
-    */
+   * Reads the contents of the given [[os.Path]] in chunks of the given size;
+   * returns a generator which provides a byte array and an offset into that
+   * array which contains the data for that chunk. All chunks will be of the
+   * given size, except for the last chunk which may be smaller.
+   *
+   * Note that the array returned by the generator is shared between each
+   * callback; make sure you copy the bytes/array somewhere else if you want
+   * to keep them around.
+   *
+   * Optionally takes in a provided input `buffer` instead of a `chunkSize`,
+   * allowing you to re-use the buffer between invocations.
+   */
   object chunks {
     def apply(p: ReadablePath, chunkSize: Int): geny.Generator[(Array[Byte], Int)] = {
       apply(p, new Array[Byte](chunkSize))
@@ -294,10 +310,10 @@ object read extends Function1[ReadablePath, String]{
       new Generator[(Array[Byte], Int)] {
         def generate(handleItem: ((Array[Byte], Int)) => Generator.Action): Generator.Action = {
           val is = os.read.inputStream(p)
-          try{
+          try {
             var bufferOffset = 0
             var lastAction: Generator.Action = Generator.Continue
-            while ( {
+            while ({
               is.read(buffer, bufferOffset, buffer.length - bufferOffset) match {
                 case -1 =>
                   if (bufferOffset != 0) lastAction = handleItem((buffer, bufferOffset))
@@ -313,7 +329,7 @@ object read extends Function1[ReadablePath, String]{
               }
             }) ()
             lastAction
-          } finally{
+          } finally {
             is.close()
           }
         }
@@ -322,37 +338,37 @@ object read extends Function1[ReadablePath, String]{
   }
 
   /**
-    * Reads the given [[os.Path]] or other [[os.Source]] as a string
-    * and splits it into lines; defaults to reading as UTF-8, which you
-    * can override by specifying a `charSet`.
-    */
-  object lines extends Function1[ReadablePath, IndexedSeq[String]]{
+   * Reads the given [[os.Path]] or other [[os.Source]] as a string
+   * and splits it into lines; defaults to reading as UTF-8, which you
+   * can override by specifying a `charSet`.
+   */
+  object lines extends Function1[ReadablePath, IndexedSeq[String]] {
     def apply(src: ReadablePath): IndexedSeq[String] = stream(src).toArray[String].toIndexedSeq
     def apply(arg: ReadablePath, charSet: Codec): IndexedSeq[String] =
       stream(arg, charSet).toArray[String].toIndexedSeq
 
     /**
-      * Identical to [[os.read.lines]], but streams the results back to you
-      * in a [[os.Generator]] rather than accumulating them in memory. Useful
-      * if the file is large.
-      */
-    object stream extends Function1[ReadablePath, geny.Generator[String]]{
+     * Identical to [[os.read.lines]], but streams the results back to you
+     * in a [[os.Generator]] rather than accumulating them in memory. Useful
+     * if the file is large.
+     */
+    object stream extends Function1[ReadablePath, geny.Generator[String]] {
       def apply(arg: ReadablePath) = apply(arg, java.nio.charset.StandardCharsets.UTF_8)
 
       def apply(arg: ReadablePath, charSet: Codec) = {
-        new geny.Generator[String]{
+        new geny.Generator[String] {
           def generate(handleItem: String => Generator.Action) = {
             val is = arg.getInputStream
             val isr = new InputStreamReader(is, charSet.decoder)
             val buf = new BufferedReader(isr)
             var currentAction: Generator.Action = Generator.Continue
             var looping = true
-            try{
-              while(looping){
-                buf.readLine() match{
+            try {
+              while (looping) {
+                buf.readLine() match {
                   case null => looping = false
                   case s =>
-                    handleItem(s) match{
+                    handleItem(s) match {
                       case Generator.Continue => // go around again
                       case Generator.End =>
                         currentAction = Generator.End
@@ -361,7 +377,7 @@ object read extends Function1[ReadablePath, String]{
                 }
               }
               currentAction
-            } finally{
+            } finally {
               is.close()
               isr.close()
               buf.close()

--- a/os/src/Source.scala
+++ b/os/src/Source.scala
@@ -18,14 +18,14 @@ import java.nio.channels.{
 import scala.language.implicitConversions
 
 /**
-  * A source of bytes; must provide either an [[InputStream]] or a
-  * [[SeekableByteChannel]] to read from. Can be constructed implicitly from
-  * strings, byte arrays, inputstreams, channels or file paths
-  */
-trait Source extends geny.Writable{
+ * A source of bytes; must provide either an [[InputStream]] or a
+ * [[SeekableByteChannel]] to read from. Can be constructed implicitly from
+ * strings, byte arrays, inputstreams, channels or file paths
+ */
+trait Source extends geny.Writable {
   override def httpContentType = Some("application/octet-stream")
   def getHandle(): Either[geny.Writable, SeekableByteChannel]
-  def writeBytesTo(out: java.io.OutputStream) = getHandle() match{
+  def writeBytesTo(out: java.io.OutputStream) = getHandle() match {
     case Left(bs) => bs.writeBytesTo(out)
 
     case Right(channel: FileChannel) =>
@@ -36,7 +36,7 @@ trait Source extends geny.Writable{
       val inChannel = Channels.newInputStream(channel)
       Internals.transfer(inChannel, out)
   }
-  def writeBytesTo(out: WritableByteChannel) = getHandle() match{
+  def writeBytesTo(out: WritableByteChannel) = getHandle() match {
     case Left(bs) =>
       val os = new BufferedOutputStream(Channels.newOutputStream(out))
       bs.writeBytesTo(os)
@@ -46,7 +46,7 @@ trait Source extends geny.Writable{
         case (src: FileChannel, dest) =>
           val size = src.size()
           var pos = 0L
-          while(pos < size) {
+          while (pos < size) {
             pos += src.transferTo(pos, size - pos, dest)
           }
         case (src, dest: FileChannel) => dest.transferFrom(src, 0, Long.MaxValue)
@@ -59,40 +59,43 @@ trait Source extends geny.Writable{
   }
 }
 
-object Source extends WritableLowPri{
-  implicit class ChannelSource(cn: SeekableByteChannel) extends Source{
+object Source extends WritableLowPri {
+  implicit class ChannelSource(cn: SeekableByteChannel) extends Source {
     def getHandle() = Right(cn)
   }
 
-  implicit class WritableSource[T](s: T)(implicit f: T => geny.Writable) extends Source{
+  implicit class WritableSource[T](s: T)(implicit f: T => geny.Writable) extends Source {
     val writable = f(s)
     def getHandle() = Left(writable)
   }
 }
 
 trait WritableLowPri {
-  implicit def WritableGenerator[T](a: geny.Generator[T])(implicit f: T => geny.Writable): Source ={
+  implicit def WritableGenerator[T](a: geny.Generator[T])(implicit
+      f: T => geny.Writable
+  ): Source = {
     val f0 = f
     new Source {
       def getHandle() = Left(
-        new geny.Writable{
+        new geny.Writable {
           def writeBytesTo(out: java.io.OutputStream) = {
-            for(x <- a) f0(x).writeBytesTo(out)
+            for (x <- a) f0(x).writeBytesTo(out)
           }
         }
       )
     }
   }
-  implicit def WritableTraversable[M[_], T](a: M[T])
-                                         (implicit f: T => geny.Writable,
-                                          g: M[T] => TraversableOnce[T]): Source = {
+  implicit def WritableTraversable[M[_], T](a: M[T])(implicit
+      f: T => geny.Writable,
+      g: M[T] => TraversableOnce[T]
+  ): Source = {
     val traversable = g(a)
     val f0 = f
     new Source {
       def getHandle() = Left(
-        new geny.Writable{
+        new geny.Writable {
           def writeBytesTo(out: java.io.OutputStream) = {
-            for(x <- traversable) f0(x).writeBytesTo(out)
+            for (x <- traversable) f0(x).writeBytesTo(out)
           }
         }
       )
@@ -101,14 +104,14 @@ trait WritableLowPri {
 }
 
 /**
-  * A source which is guaranteeds to provide a [[SeekableByteChannel]]
-  */
-trait SeekableSource extends Source{
+ * A source which is guaranteeds to provide a [[SeekableByteChannel]]
+ */
+trait SeekableSource extends Source {
   def getHandle(): Right[geny.Writable, SeekableByteChannel]
   def getChannel() = getHandle().right.get
 }
 
-object SeekableSource{
+object SeekableSource {
   implicit class ChannelSource(cn: SeekableByteChannel) extends SeekableSource {
     def getHandle() = Right(cn)
   }

--- a/os/src/StatOps.scala
+++ b/os/src/StatOps.scala
@@ -5,75 +5,73 @@ import java.nio.file.attribute._
 
 import scala.util.Try
 
-
 /**
-  * Checks whether the given path is a symbolic link
-  *
-  * Returns `false` if the path does not exist
-  */
-object isLink extends Function1[Path, Boolean]{
+ * Checks whether the given path is a symbolic link
+ *
+ * Returns `false` if the path does not exist
+ */
+object isLink extends Function1[Path, Boolean] {
   def apply(p: Path): Boolean = Files.isSymbolicLink(p.wrapped)
 }
 
 /**
-  * Checks whether the given path is a regular file
-  *
-  * Returns `false` if the path does not exist
-  */
-object isFile extends Function1[Path, Boolean]{
+ * Checks whether the given path is a regular file
+ *
+ * Returns `false` if the path does not exist
+ */
+object isFile extends Function1[Path, Boolean] {
   def apply(p: Path): Boolean = Files.isRegularFile(p.wrapped)
   def apply(p: Path, followLinks: Boolean = true): Boolean = {
     val opts = if (followLinks) Array[LinkOption]() else Array(LinkOption.NOFOLLOW_LINKS)
-    Files.isRegularFile(p.wrapped, opts:_*)
+    Files.isRegularFile(p.wrapped, opts: _*)
   }
 }
 
-
 /**
-  * Checks whether the given path is a directory
-  *
-  * Returns `false` if the path does not exist
-  */
-object isDir extends Function1[Path, Boolean]{
+ * Checks whether the given path is a directory
+ *
+ * Returns `false` if the path does not exist
+ */
+object isDir extends Function1[Path, Boolean] {
   def apply(p: Path): Boolean = Files.isDirectory(p.wrapped)
   def apply(p: Path, followLinks: Boolean = true): Boolean = {
     val opts = if (followLinks) Array[LinkOption]() else Array(LinkOption.NOFOLLOW_LINKS)
-    Files.isDirectory(p.wrapped, opts:_*)
+    Files.isDirectory(p.wrapped, opts: _*)
   }
 }
 
 /**
-  * Gets the size of the given file or folder
-  *
-  * Throws an exception if the file or folder does not exist
-  *
-  * When called on folders, returns the size of the folder metadata
-  * (i.e. the list of children names), and not the size of the folder's
-  * recursive contents. Use [[os.walk]] if you want to sum up the total
-  * size of a directory tree.
-  */
-object size extends Function1[Path, Long]{
+ * Gets the size of the given file or folder
+ *
+ * Throws an exception if the file or folder does not exist
+ *
+ * When called on folders, returns the size of the folder metadata
+ * (i.e. the list of children names), and not the size of the folder's
+ * recursive contents. Use [[os.walk]] if you want to sum up the total
+ * size of a directory tree.
+ */
+object size extends Function1[Path, Long] {
   def apply(p: Path): Long = Files.size(p.wrapped)
 }
 
 /**
-  * Gets the mtime of the given file or directory
-  */
-object mtime extends Function1[Path, Long]{
+ * Gets the mtime of the given file or directory
+ */
+object mtime extends Function1[Path, Long] {
   def apply(p: Path): Long = Files.getLastModifiedTime(p.wrapped).toMillis
   def apply(p: Path, followLinks: Boolean = true): Long = {
     val opts = if (followLinks) Array[LinkOption]() else Array(LinkOption.NOFOLLOW_LINKS)
-    Files.getLastModifiedTime(p.wrapped, opts:_*).toMillis
+    Files.getLastModifiedTime(p.wrapped, opts: _*).toMillis
   }
 
   /**
-    * Sets the mtime of the given file.
-    *
-    * Note that this always follows links to set the mtime of the referred-to file.
-    * Unfortunately there is no Java API to set the mtime of the link itself:
-    *
-    * https://stackoverflow.com/questions/17308363/symlink-lastmodifiedtime-in-java-1-7
-    */
+   * Sets the mtime of the given file.
+   *
+   * Note that this always follows links to set the mtime of the referred-to file.
+   * Unfortunately there is no Java API to set the mtime of the link itself:
+   *
+   * https://stackoverflow.com/questions/17308363/symlink-lastmodifiedtime-in-java-1-7
+   */
   object set {
     def apply(p: Path, millis: Long) = {
       Files.setLastModifiedTime(p.wrapped, FileTime.fromMillis(millis))
@@ -82,28 +80,28 @@ object mtime extends Function1[Path, Long]{
 }
 
 /**
-  * Reads in the basic filesystem metadata for the given file. By default follows
-  * symbolic links to read the metadata of whatever the link is pointing at; set
-  * `followLinks = false` to disable that and instead read the metadata of the
-  * symbolic link itself.
-  *
-  * Throws an exception if the file or folder does not exist
-  */
-object stat extends Function1[os.Path, os.StatInfo]{
+ * Reads in the basic filesystem metadata for the given file. By default follows
+ * symbolic links to read the metadata of whatever the link is pointing at; set
+ * `followLinks = false` to disable that and instead read the metadata of the
+ * symbolic link itself.
+ *
+ * Throws an exception if the file or folder does not exist
+ */
+object stat extends Function1[os.Path, os.StatInfo] {
   def apply(p: os.Path): os.StatInfo = apply(p, followLinks = true)
   def apply(p: os.Path, followLinks: Boolean = true): os.StatInfo = {
     val opts = if (followLinks) Array[LinkOption]() else Array(LinkOption.NOFOLLOW_LINKS)
-    os.StatInfo.make(Files.readAttributes(p.wrapped, classOf[BasicFileAttributes], opts:_*))
+    os.StatInfo.make(Files.readAttributes(p.wrapped, classOf[BasicFileAttributes], opts: _*))
   }
 
   /**
-    * Reads POSIX metadata for the given file: ownership and permissions data
-    */
-  object posix{
+   * Reads POSIX metadata for the given file: ownership and permissions data
+   */
+  object posix {
     def apply(p: os.Path): os.PosixStatInfo = apply(p, followLinks = true)
     def apply(p: os.Path, followLinks: Boolean = true): os.PosixStatInfo = {
       val opts = if (followLinks) Array[LinkOption]() else Array(LinkOption.NOFOLLOW_LINKS)
-      os.PosixStatInfo.make(Files.readAttributes(p.wrapped, classOf[PosixFileAttributes], opts:_*))
+      os.PosixStatInfo.make(Files.readAttributes(p.wrapped, classOf[PosixFileAttributes], opts: _*))
     }
   }
 }

--- a/os/src/TempOps.scala
+++ b/os/src/TempOps.scala
@@ -2,38 +2,40 @@ package os
 
 import java.nio.file.attribute.{FileAttribute, PosixFilePermission, PosixFilePermissions}
 
-
 /**
-  * Alias for `java.nio.file.Files.createTempFile` and
-  * `java.io.File.deleteOnExit`. Pass in `deleteOnExit = false` if you want
-  * the temp file to stick around.
-  */
-object temp{
+ * Alias for `java.nio.file.Files.createTempFile` and
+ * `java.io.File.deleteOnExit`. Pass in `deleteOnExit = false` if you want
+ * the temp file to stick around.
+ */
+object temp {
+
   /**
-    * Creates a temporary file. You can optionally provide a `dir` to specify where
-    * this file lives, file-`prefix` and file-`suffix` to customize what it looks
-    * like, and a [[PermSet]] to customize its filesystem permissions.
-    *
-    * Passing in a [[os.Source]] will initialize the contents of that file to
-    * the provided data; otherwise it is created empty.
-    *
-    * By default, temporary files are deleted on JVM exit. You can disable that
-    * behavior by setting `deleteOnExit = false`
-    */
-  def apply(contents: Source = null,
-            dir: Path = null,
-            prefix: String = null,
-            suffix: String = null,
-            deleteOnExit: Boolean = true,
-            perms: PermSet = null): Path = {
+   * Creates a temporary file. You can optionally provide a `dir` to specify where
+   * this file lives, file-`prefix` and file-`suffix` to customize what it looks
+   * like, and a [[PermSet]] to customize its filesystem permissions.
+   *
+   * Passing in a [[os.Source]] will initialize the contents of that file to
+   * the provided data; otherwise it is created empty.
+   *
+   * By default, temporary files are deleted on JVM exit. You can disable that
+   * behavior by setting `deleteOnExit = false`
+   */
+  def apply(
+      contents: Source = null,
+      dir: Path = null,
+      prefix: String = null,
+      suffix: String = null,
+      deleteOnExit: Boolean = true,
+      perms: PermSet = null
+  ): Path = {
     import collection.JavaConverters._
     val permArray: Array[FileAttribute[_]] =
       if (perms == null) Array.empty
       else Array(PosixFilePermissions.asFileAttribute(perms.toSet()))
 
-    val nioPath = dir match{
-      case null => java.nio.file.Files.createTempFile(prefix, suffix, permArray:_*)
-      case _ => java.nio.file.Files.createTempFile(dir.wrapped, prefix, suffix, permArray:_*)
+    val nioPath = dir match {
+      case null => java.nio.file.Files.createTempFile(prefix, suffix, permArray: _*)
+      case _ => java.nio.file.Files.createTempFile(dir.wrapped, prefix, suffix, permArray: _*)
     }
 
     if (contents != null) write.over(Path(nioPath), contents)
@@ -42,24 +44,26 @@ object temp{
   }
 
   /**
-    * Creates a temporary directory. You can optionally provide a `dir` to specify
-    * where this file lives, a `prefix` to customize what it looks like, and a
-    * [[PermSet]] to customize its filesystem permissions.
-    *
-    * By default, temporary directories are deleted on JVM exit. You can disable that
-    * behavior by setting `deleteOnExit = false`
-    */
-  def dir(dir: Path = null,
-          prefix: String = null,
-          deleteOnExit: Boolean = true,
-          perms: PermSet = null): Path = {
+   * Creates a temporary directory. You can optionally provide a `dir` to specify
+   * where this file lives, a `prefix` to customize what it looks like, and a
+   * [[PermSet]] to customize its filesystem permissions.
+   *
+   * By default, temporary directories are deleted on JVM exit. You can disable that
+   * behavior by setting `deleteOnExit = false`
+   */
+  def dir(
+      dir: Path = null,
+      prefix: String = null,
+      deleteOnExit: Boolean = true,
+      perms: PermSet = null
+  ): Path = {
     val permArray: Array[FileAttribute[_]] =
       if (perms == null) Array.empty
       else Array(PosixFilePermissions.asFileAttribute(perms.toSet()))
 
-    val nioPath = dir match{
-      case null => java.nio.file.Files.createTempDirectory(prefix, permArray:_*)
-      case _ => java.nio.file.Files.createTempDirectory(dir.wrapped, prefix, permArray:_*)
+    val nioPath = dir match {
+      case null => java.nio.file.Files.createTempDirectory(prefix, permArray: _*)
+      case _ => java.nio.file.Files.createTempDirectory(dir.wrapped, prefix, permArray: _*)
     }
 
     if (deleteOnExit) nioPath.toFile.deleteOnExit()

--- a/os/watch/src/CarbonApi.scala
+++ b/os/watch/src/CarbonApi.scala
@@ -9,29 +9,40 @@ object CarbonApi {
 }
 
 trait FSEventStreamCallback extends Callback {
-  def invoke(streamRef: FSEventStreamRef,
-             clientCallBackInfo: Pointer,
-             numEvents: NativeLong,
-             eventPaths: Pointer,
-             eventFlags: Pointer,
-             eventIds: Pointer): Unit
+  def invoke(
+      streamRef: FSEventStreamRef,
+      clientCallBackInfo: Pointer,
+      numEvents: NativeLong,
+      eventPaths: Pointer,
+      eventFlags: Pointer,
+      eventIds: Pointer
+  ): Unit
 }
 
 trait CarbonApi extends Library {
-  def CFArrayCreate(allocator: CFAllocatorRef, // always set to Pointer.NULL
-                    values: Array[Pointer], numValues: CFIndex, callBacks: Void): CFArrayRef
+  def CFArrayCreate(
+      allocator: CFAllocatorRef, // always set to Pointer.NULL
+      values: Array[Pointer],
+      numValues: CFIndex,
+      callBacks: Void
+  ): CFArrayRef
 
   // always set to Pointer.NULL): CFArrayRef
-  def CFStringCreateWithCharacters(alloc: Void, //  always pass NULL
-                                   chars: Array[Char], numChars: CFIndex): CFStringRef
+  def CFStringCreateWithCharacters(
+      alloc: Void, //  always pass NULL
+      chars: Array[Char],
+      numChars: CFIndex
+  ): CFStringRef
 
-  def FSEventStreamCreate(v: Pointer, // always use Pointer.NULL
-                          callback: FSEventStreamCallback,
-                          context: Pointer,
-                          pathsToWatch: CFArrayRef,
-                          sinceWhen: Long, // use -1 for events since now
-                          latency: Double, // in seconds
-                          flags: Int): FSEventStreamRef
+  def FSEventStreamCreate(
+      v: Pointer, // always use Pointer.NULL
+      callback: FSEventStreamCallback,
+      context: Pointer,
+      pathsToWatch: CFArrayRef,
+      sinceWhen: Long, // use -1 for events since now
+      latency: Double, // in seconds
+      flags: Int
+  ): FSEventStreamRef
 
   // 0 is good for now): FSEventStreamRef
   def FSEventStreamStart(streamRef: FSEventStreamRef): Boolean
@@ -39,14 +50,18 @@ trait CarbonApi extends Library {
   def FSEventStreamStop(streamRef: FSEventStreamRef): Unit
 
   def FSEventStreamInvalidate(streamRef: FSEventStreamRef): Unit
-  def FSEventStreamUnscheduleFromRunLoop(streamRef: FSEventStreamRef,
-                                         runLoop: CFRunLoopRef,
-                                         runLoopMode: CFStringRef): Unit
+  def FSEventStreamUnscheduleFromRunLoop(
+      streamRef: FSEventStreamRef,
+      runLoop: CFRunLoopRef,
+      runLoopMode: CFStringRef
+  ): Unit
   def FSEventStreamRelease(streamRef: FSEventStreamRef): Unit
 
-  def FSEventStreamScheduleWithRunLoop(streamRef: FSEventStreamRef,
-                                       runLoop: CFRunLoopRef,
-                                       runLoopMode: CFStringRef): Unit
+  def FSEventStreamScheduleWithRunLoop(
+      streamRef: FSEventStreamRef,
+      runLoop: CFRunLoopRef,
+      runLoopMode: CFStringRef
+  ): Unit
 
   def CFRunLoopGetCurrent(): CFRunLoopRef
 
@@ -55,12 +70,9 @@ trait CarbonApi extends Library {
   def CFRunLoopStop(rl: CFRunLoopRef): Unit
 }
 
-
 class CFAllocatorRef extends PointerByReference {}
 
-
 class CFArrayRef extends PointerByReference {}
-
 
 @SerialVersionUID(0)
 object CFIndex {
@@ -74,9 +86,7 @@ object CFIndex {
 @SerialVersionUID(0)
 class CFIndex extends NativeLong {}
 
-
 class CFRunLoopRef extends PointerByReference {}
-
 
 object CFStringRef {
   def toCFString(s: String) = {
@@ -87,6 +97,5 @@ object CFStringRef {
 }
 
 class CFStringRef extends PointerByReference {}
-
 
 class FSEventStreamRef extends PointerByReference {}

--- a/os/watch/src/WatchServiceWatcher.scala
+++ b/os/watch/src/WatchServiceWatcher.scala
@@ -11,9 +11,11 @@ import com.sun.nio.file.SensitivityWatchEventModifier
 import scala.collection.mutable
 import collection.JavaConverters._
 
-class WatchServiceWatcher(roots: Seq[os.Path],
-                          onEvent: Set[os.Path] => Unit,
-                          logger: (String, Any) => Unit = (_, _) => ()) extends Watcher{
+class WatchServiceWatcher(
+    roots: Seq[os.Path],
+    onEvent: Set[os.Path] => Unit,
+    logger: (String, Any) => Unit = (_, _) => ()
+) extends Watcher {
 
   val nioWatchService = FileSystems.getDefault.newWatchService()
   val currentlyWatchedPaths = mutable.Map.empty[os.Path, WatchKey]
@@ -54,11 +56,11 @@ class WatchServiceWatcher(roots: Seq[os.Path],
 
     logger("WATCH KINDS", events.map(_.kind()))
 
-    for(e <- events){
+    for (e <- events) {
       bufferedEvents.add(p / e.context().toString)
     }
 
-    for(e <- events if e.kind() == ENTRY_CREATE){
+    for (e <- events if e.kind() == ENTRY_CREATE) {
       watchSinglePath(p / e.context().toString)
     }
 
@@ -66,52 +68,55 @@ class WatchServiceWatcher(roots: Seq[os.Path],
   }
 
   def recursiveWatches() = {
-    while(newlyWatchedPaths.nonEmpty){
+    while (newlyWatchedPaths.nonEmpty) {
       val top = newlyWatchedPaths.remove(newlyWatchedPaths.length - 1)
-      val listing = try os.list(top) catch {case e: java.nio.file.NotDirectoryException => Nil }
-      for(p <- listing) watchSinglePath(p)
+      val listing =
+        try os.list(top)
+        catch { case e: java.nio.file.NotDirectoryException => Nil }
+      for (p <- listing) watchSinglePath(p)
       bufferedEvents.add(top)
     }
   }
 
   def run(): Unit = {
-    while (isRunning.get()) try {
-      logger("WATCH CURRENT", currentlyWatchedPaths)
-      val watchKey0 = nioWatchService.take()
-      if (watchKey0 != null){
-        logger("WATCH KEY0", watchKey0.watchable())
-        processEvent(watchKey0)
-        while({
-          nioWatchService.poll() match{
-            case null => false
-            case watchKey =>
-              logger("WATCH KEY", watchKey.watchable())
-              processEvent(watchKey)
-              true
-          }
-        })()
+    while (isRunning.get())
+      try {
+        logger("WATCH CURRENT", currentlyWatchedPaths)
+        val watchKey0 = nioWatchService.take()
+        if (watchKey0 != null) {
+          logger("WATCH KEY0", watchKey0.watchable())
+          processEvent(watchKey0)
+          while ({
+            nioWatchService.poll() match {
+              case null => false
+              case watchKey =>
+                logger("WATCH KEY", watchKey.watchable())
+                processEvent(watchKey)
+                true
+            }
+          }) ()
 
-        // cleanup stale watches, but do so before we register new ones
-        // because when folders are moved, the old watch is moved as well
-        // and we need to make sure we re-register the watch after disabling
-        // it due to the old file path within the old folder no longer existing
-        for(p <- currentlyWatchedPaths.keySet if !os.isDir(p, followLinks = false)){
-          logger("WATCH CANCEL", p)
-          currentlyWatchedPaths.remove(p).foreach(_.cancel())
+          // cleanup stale watches, but do so before we register new ones
+          // because when folders are moved, the old watch is moved as well
+          // and we need to make sure we re-register the watch after disabling
+          // it due to the old file path within the old folder no longer existing
+          for (p <- currentlyWatchedPaths.keySet if !os.isDir(p, followLinks = false)) {
+            logger("WATCH CANCEL", p)
+            currentlyWatchedPaths.remove(p).foreach(_.cancel())
+          }
+
+          recursiveWatches()
+          triggerListener()
         }
 
-        recursiveWatches()
-        triggerListener()
+      } catch {
+        case e: InterruptedException =>
+          println("Interrupted, exiting: " + e)
+          isRunning.set(false)
+        case e: ClosedWatchServiceException =>
+          println("Watcher closed, exiting: " + e)
+          isRunning.set(false)
       }
-
-    } catch {
-      case e: InterruptedException =>
-        println("Interrupted, exiting: " + e)
-        isRunning.set(false)
-      case e: ClosedWatchServiceException =>
-        println("Watcher closed, exiting: " + e)
-        isRunning.set(false)
-    }
   }
 
   def close(): Unit = {

--- a/os/watch/src/Watcher.scala
+++ b/os/watch/src/Watcher.scala
@@ -1,5 +1,5 @@
 package os.watch
 
-abstract class Watcher extends AutoCloseable{
+abstract class Watcher extends AutoCloseable {
   def run(): Unit
 }

--- a/os/watch/src/package.scala
+++ b/os/watch/src/package.scala
@@ -1,36 +1,38 @@
 package os
 
-package object watch{
+package object watch {
+
   /**
-    * Efficiently watches the given `roots` folders for changes. Any time the
-    * filesystem is modified within those folders, the `onEvent` callback is
-    * called with the paths to the changed files or folders.
-    *
-    * Once the call to `watch` returns, `onEvent` is guaranteed to receive a
-    * an event containing the path for:
-    *
-    * - Every file or folder that gets created, deleted, updated or moved
-    *   within the watched folders
-    *
-    * - For copied or moved folders, the path of the new folder as well as
-    *   every file or folder within it.
-    *
-    *
-    * - For deleted or moved folders, the root folder which was deleted/moved,
-    *   but *without* the paths of every file that was within it at the
-    *   original location
-    *
-    * Note that `watch` does not provide any additional information about the
-    * changes happening within the watched roots folder, apart from the path
-    * at which the change happened. It is up to the `onEvent` handler to query
-    * the filesystem and figure out what happened, and what it wants to do.
-    *
-    * `watch` currently only supports Linux and Mac-OSX, and not Windows.
-    */
-  def watch(roots: Seq[os.Path],
-            onEvent: Set[os.Path] => Unit,
-            logger: (String, Any) => Unit = (_, _) => ()): AutoCloseable  = {
-    val watcher = System.getProperty("os.name") match{
+   * Efficiently watches the given `roots` folders for changes. Any time the
+   * filesystem is modified within those folders, the `onEvent` callback is
+   * called with the paths to the changed files or folders.
+   *
+   * Once the call to `watch` returns, `onEvent` is guaranteed to receive a
+   * an event containing the path for:
+   *
+   * - Every file or folder that gets created, deleted, updated or moved
+   *   within the watched folders
+   *
+   * - For copied or moved folders, the path of the new folder as well as
+   *   every file or folder within it.
+   *
+   * - For deleted or moved folders, the root folder which was deleted/moved,
+   *   but *without* the paths of every file that was within it at the
+   *   original location
+   *
+   * Note that `watch` does not provide any additional information about the
+   * changes happening within the watched roots folder, apart from the path
+   * at which the change happened. It is up to the `onEvent` handler to query
+   * the filesystem and figure out what happened, and what it wants to do.
+   *
+   * `watch` currently only supports Linux and Mac-OSX, and not Windows.
+   */
+  def watch(
+      roots: Seq[os.Path],
+      onEvent: Set[os.Path] => Unit,
+      logger: (String, Any) => Unit = (_, _) => ()
+  ): AutoCloseable = {
+    val watcher = System.getProperty("os.name") match {
       case "Linux" => new os.watch.WatchServiceWatcher(roots, onEvent, logger)
       case "Mac OS X" => new os.watch.FSEventsWatcher(roots, onEvent, logger, 0.05)
       case osName => throw new Exception(s"watch not supported on operating system: $osName")


### PR DESCRIPTION
This PR adds in 2 commits. One being a formatting commit since there is a `.scalafmt.conf` in this repo, but it was never enforced. The second commit adds a check in CI for formatting and also creates a `.git-blame-ignore-revs` file with the formatting commit in it.