### PR TITLE
fix: handle `baseName` for hidden dirs

### DIFF
--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -200,7 +200,8 @@ trait BasePathImpl extends BasePath {
 
   override def baseName: String = {
     val li = last.lastIndexOf('.')
-    if (li == -1) last
+    // We also check 0 for things like hidden files/directories that start with .
+    if (li == -1 || li == 0) last
     else last.slice(0, li)
   }
 

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -54,6 +54,7 @@ object PathTests extends TestSuite{
           assert((base / "baseName.v2.0.ext").baseName == "baseName.v2.0")
           assert((base / "baseOnly").baseName == "baseOnly")
           assert((base / "baseOnly.").baseName == "baseOnly")
+          assert((base / ".well-known").baseName == ".well-known")
         }
 
         test("ext"){


### PR DESCRIPTION
I had a usecase for this when I was working with `.well-known` as a dir
and got bite by this since `baseName` on this will just return `""`.
This changes the logic slightly to return `last` if either `-1` is found
meaning there is no `.` in the file, or if the index is `0` indicating
that it's hidden and there is also no extension. I've also added a test
for this.
