### PR TITLE
Update Scalafmt setup and reformatted test sources

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,6 @@
 # Format the codebase for the first time
 b049841d5707d5bd87be516d8cda7be2a7585eae
+
+# Reformatted test code
+e437d63c40713e0645a4895bbe5a0fc565cd56db
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,9 +59,9 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 17
 
-      - run: ./mill -i -k __.checkFormat
+      - run: ./mill -i mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources
 
   publish-sonatype:
     if: github.repository == 'com-lihaoyi/os-lib' && contains(github.ref, 'refs/tags/')

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.5.8"
+version = "3.7.3"
 
 align.preset = none
 align.openParenCallSite = false

--- a/build.sc
+++ b/build.sc
@@ -6,7 +6,6 @@ import $ivy.`com.github.lolgab::mill-mima::0.0.13`
 import mill._
 import mill.define.{Task, Target}
 import mill.scalalib._
-import mill.scalalib.scalafmt._
 import mill.scalanativelib._
 import mill.scalalib.publish._
 import mill.scalalib.api.ZincWorkerUtil
@@ -125,8 +124,7 @@ trait SafeDeps extends ScalaModule {
   }
 }
 
-trait OsLibModule extends CrossScalaModule with PublishModule with AcyclicModule with SafeDeps
-    with ScalafmtModule {
+trait OsLibModule extends CrossScalaModule with PublishModule with AcyclicModule with SafeDeps {
   def publishVersion = VcsVersion.vcsState().format()
   def pomSettings = PomSettings(
     description = artifactName(),

--- a/os/test/src-jvm/ExampleTests.scala
+++ b/os/test/src-jvm/ExampleTests.scala
@@ -3,71 +3,75 @@ package test.os
 import java.nio.file.attribute.{GroupPrincipal, FileTime}
 
 import utest._
-object ExampleTests extends TestSuite{
+object ExampleTests extends TestSuite {
 
   val tests = Tests {
-    test("splash") - TestUtil.prep{wd => if (Unix()){
-      // Make sure working directory exists and is empty
-      val wd = os.pwd/"out"/"splash"
-      os.remove.all(wd)
-      os.makeDir.all(wd)
+    test("splash") - TestUtil.prep { wd =>
+      if (Unix()) {
+        // Make sure working directory exists and is empty
+        val wd = os.pwd / "out" / "splash"
+        os.remove.all(wd)
+        os.makeDir.all(wd)
 
-      os.write(wd/"file.txt", "hello")
-      os.read(wd/"file.txt") ==> "hello"
+        os.write(wd / "file.txt", "hello")
+        os.read(wd / "file.txt") ==> "hello"
 
-      os.copy(wd/"file.txt", wd/"copied.txt")
-      os.list(wd) ==> Seq(wd/"copied.txt", wd/"file.txt")
+        os.copy(wd / "file.txt", wd / "copied.txt")
+        os.list(wd) ==> Seq(wd / "copied.txt", wd / "file.txt")
 
-      val invoked = os.proc("cat", wd/"file.txt", wd/"copied.txt").call(cwd = wd)
-      invoked.out.trim() ==> "hellohello"
-    }}
+        val invoked = os.proc("cat", wd / "file.txt", wd / "copied.txt").call(cwd = wd)
+        invoked.out.trim() ==> "hellohello"
+      }
+    }
 
-    test("concatTxt") - TestUtil.prep{wd =>
+    test("concatTxt") - TestUtil.prep { wd =>
       // Find and concatenate all .txt files directly in the working directory
       os.write(
-        wd/"all.txt",
+        wd / "all.txt",
         os.list(wd).filter(_.ext == "txt").map(os.read)
       )
 
-      os.read(wd/"all.txt") ==>
+      os.read(wd / "all.txt") ==>
         """I am cowI am cow
           |Hear me moo
           |I weigh twice as much as you
           |And I look good on the barbecue""".stripMargin
     }
 
-    test("subprocessConcat") - TestUtil.prep{wd =>
-      val catCmd = if(scala.util.Properties.isWin) "type" else "cat"
+    test("subprocessConcat") - TestUtil.prep { wd =>
+      val catCmd = if (scala.util.Properties.isWin) "type" else "cat"
       // Find and concatenate all .txt files directly in the working directory
       TestUtil.proc(catCmd, os.list(wd).filter(_.ext == "txt"))
-        .call(stdout = wd/"all.txt")
+        .call(stdout = wd / "all.txt")
 
-      os.read(wd/"all.txt") ==>
+      os.read(wd / "all.txt") ==>
         """I am cowI am cow
           |Hear me moo
           |I weigh twice as much as you
           |And I look good on the barbecue""".stripMargin
     }
 
-    test("curlToTempFile") - TestUtil.prep{wd => if (Unix()){
-      // Curl to temporary file
-      val temp = os.temp()
-      os.proc("curl", "-L" , ExampleResourcess.RemoteReadme.url)
-        .call(stdout = temp)
+    test("curlToTempFile") - TestUtil.prep { wd =>
+      if (Unix()) {
+        // Curl to temporary file
+        val temp = os.temp()
+        os.proc("curl", "-L", ExampleResourcess.RemoteReadme.url)
+          .call(stdout = temp)
 
-      os.size(temp) ==> ExampleResourcess.RemoteReadme.size
+        os.size(temp) ==> ExampleResourcess.RemoteReadme.size
 
-      // Curl to temporary file
-      val temp2 = os.temp()
-      val proc = os.proc("curl", "-L" , ExampleResourcess.RemoteReadme.url).spawn()
+        // Curl to temporary file
+        val temp2 = os.temp()
+        val proc = os.proc("curl", "-L", ExampleResourcess.RemoteReadme.url).spawn()
 
-      os.write.over(temp2, proc.stdout)
-      os.size(temp2) ==> ExampleResourcess.RemoteReadme.size
+        os.write.over(temp2, proc.stdout)
+        os.size(temp2) ==> ExampleResourcess.RemoteReadme.size
 
-      assert(os.size(temp) == os.size(temp2))
-    }}
+        assert(os.size(temp) == os.size(temp2))
+      }
+    }
 
-    test("lineCount") - TestUtil.prep{wd =>
+    test("lineCount") - TestUtil.prep { wd =>
       // Line-count of all .txt files recursively in wd
       val lineCount = os.walk(wd)
         .filter(_.ext == "txt")
@@ -78,7 +82,7 @@ object ExampleTests extends TestSuite{
       lineCount ==> 9
     }
 
-    test("largestThree") - TestUtil.prep{ wd =>
+    test("largestThree") - TestUtil.prep { wd =>
       // Find the largest three files in the given folder tree
       val largestThree = os.walk(wd)
         .filter(os.isFile(_, followLinks = false))
@@ -96,29 +100,33 @@ object ExampleTests extends TestSuite{
       )
     }
 
-    test("moveOut") - TestUtil.prep{ wd =>
+    test("moveOut") - TestUtil.prep { wd =>
       // Move all files inside the "misc" folder out of it
       import os.{GlobSyntax, /}
-      os.list(wd/"misc").map(os.move.matching{case p/"misc"/x => p/x })
+      os.list(wd / "misc").map(os.move.matching { case p / "misc" / x => p / x })
     }
 
-    test("frequency") - TestUtil.prep{ wd =>
+    test("frequency") - TestUtil.prep { wd =>
       // Calculate the word frequency of all the text files in the folder tree
       def txt = os.walk(wd).filter(_.ext == "txt").map(os.read)
       def freq(s: Seq[String]) = s.groupBy(x => x).mapValues(_.length).toSeq
       val map = freq(txt.flatMap(_.split("[^a-zA-Z0-9_]"))).sortBy(-_._2)
       map
     }
-    test("comparison"){
+    test("comparison") {
 
-      os.remove.all(os.pwd/"out"/"scratch"/"folder"/"thing"/"file")
-      os.write(os.pwd/"out"/"scratch"/"folder"/"thing"/"file", "Hello!", createFolders = true)
+      os.remove.all(os.pwd / "out" / "scratch" / "folder" / "thing" / "file")
+      os.write(
+        os.pwd / "out" / "scratch" / "folder" / "thing" / "file",
+        "Hello!",
+        createFolders = true
+      )
 
       def removeAll(path: String) = {
         def getRecursively(f: java.io.File): Seq[java.io.File] = {
           f.listFiles.filter(_.isDirectory).flatMap(getRecursively) ++ f.listFiles
         }
-        getRecursively(new java.io.File(path)).foreach{f =>
+        getRecursively(new java.io.File(path)).foreach { f =>
           println(f)
           if (!f.delete())
             throw new RuntimeException("Failed to delete " + f.getAbsolutePath)
@@ -127,15 +135,19 @@ object ExampleTests extends TestSuite{
       }
       removeAll("out/scratch/folder/thing")
 
-      assert(os.list(os.pwd/"out"/"scratch"/"folder").toSeq == Nil)
+      assert(os.list(os.pwd / "out" / "scratch" / "folder").toSeq == Nil)
 
-      os.write(os.pwd/"out"/"scratch"/"folder"/"thing"/"file", "Hello!", createFolders = true)
+      os.write(
+        os.pwd / "out" / "scratch" / "folder" / "thing" / "file",
+        "Hello!",
+        createFolders = true
+      )
 
-      os.remove.all(os.pwd/"out"/"scratch"/"folder"/"thing")
-      assert(os.list(os.pwd/"out"/"scratch"/"folder").toSeq == Nil)
+      os.remove.all(os.pwd / "out" / "scratch" / "folder" / "thing")
+      assert(os.list(os.pwd / "out" / "scratch" / "folder").toSeq == Nil)
     }
 
-    test("constructingPaths"){
+    test("constructingPaths") {
 
       // Get the process' Current Working Directory. As a convention
       // the directory that "this" code cares about (which may differ
@@ -143,105 +155,106 @@ object ExampleTests extends TestSuite{
       val wd = os.pwd
 
       // A path nested inside `wd`
-      wd/"folder"/"file"
+      wd / "folder" / "file"
 
       // A path starting from the root
-      os.root/"folder"/"file"
+      os.root / "folder" / "file"
 
       // A path with spaces or other special characters
-      wd/"My Folder"/"My File.txt"
+      wd / "My Folder" / "My File.txt"
 
       // Up one level from the wd
-      wd/os.up
+      wd / os.up
 
       // Up two levels from the wd
-      wd/os.up/os.up
+      wd / os.up / os.up
     }
-    test("newPath"){
+    test("newPath") {
 
-      val target = os.pwd/"out"/"scratch"
+      val target = os.pwd / "out" / "scratch"
     }
-    test("relPaths"){
+    test("relPaths") {
 
       // The path "folder/file"
-      val rel1 = os.rel/"folder"/"file"
-      val rel2 = os.rel/"folder"/"file"
+      val rel1 = os.rel / "folder" / "file"
+      val rel2 = os.rel / "folder" / "file"
 
       // The relative difference between two paths
-      val target = os.pwd/"out"/"scratch"/"file"
-      assert((target relativeTo os.pwd) == os.rel/"out"/"scratch"/"file")
+      val target = os.pwd / "out" / "scratch" / "file"
+      assert((target relativeTo os.pwd) == os.rel / "out" / "scratch" / "file")
 
       // `up`s get resolved automatically
       val minus = os.pwd relativeTo target
-      val ups = os.up/os.up/os.up
+      val ups = os.up / os.up / os.up
       assert(minus == ups)
       (
         rel1: os.RelPath,
         rel2: os.RelPath
       )
     }
-    test("subPaths"){
+    test("subPaths") {
 
       // The path "folder/file"
-      val sub1 = os.sub/"folder"/"file"
-      val sub2 = os.sub/"folder"/"file"
+      val sub1 = os.sub / "folder" / "file"
+      val sub2 = os.sub / "folder" / "file"
 
       // The relative difference between two paths
-      val target = os.pwd/"out"/"scratch"/"file"
-      assert((target subRelativeTo os.pwd) == os.sub/"out"/"scratch"/"file")
+      val target = os.pwd / "out" / "scratch" / "file"
+      assert((target subRelativeTo os.pwd) == os.sub / "out" / "scratch" / "file")
 
       // Converting os.RelPath to os.SubPath
-      val rel3 = os.rel/"folder"/"file"
+      val rel3 = os.rel / "folder" / "file"
       val sub3 = rel3.asSubPath
-
 
       // `up`s are not allowed in sub paths
       intercept[Exception](os.pwd subRelativeTo target)
     }
-    test("relSubPathEquality"){
+    test("relSubPathEquality") {
       assert(
-        (os.sub/"hello"/"world") == (os.rel/"hello"/"world"),
+        (os.sub / "hello" / "world") == (os.rel / "hello" / "world"),
         os.sub == os.rel
       )
     }
-    test("relPathCombine"){
-      val target = os.pwd/"out"/"scratch"/"file"
+    test("relPathCombine") {
+      val target = os.pwd / "out" / "scratch" / "file"
       val rel = target relativeTo os.pwd
-      val newBase = os.root/"code"/"server"
-      assert(newBase/rel == os.root/"code"/"server"/"out"/"scratch"/"file")
+      val newBase = os.root / "code" / "server"
+      assert(newBase / rel == os.root / "code" / "server" / "out" / "scratch" / "file")
     }
-    test("subPathCombine"){
-      val target = os.pwd/"out"/"scratch"/"file"
+    test("subPathCombine") {
+      val target = os.pwd / "out" / "scratch" / "file"
       val sub = target subRelativeTo os.pwd
-      val newBase = os.root/"code"/"server"
+      val newBase = os.root / "code" / "server"
       assert(
-        newBase/sub == os.root/"code"/"server"/"out"/"scratch"/"file",
-        sub / sub == os.sub/"out"/"scratch"/"file"/"out"/"scratch"/"file"
+        newBase / sub == os.root / "code" / "server" / "out" / "scratch" / "file",
+        sub / sub == os.sub / "out" / "scratch" / "file" / "out" / "scratch" / "file"
       )
     }
-    test("pathUp"){
-      val target = os.root/"out"/"scratch"/"file"
-      assert(target/os.up == os.root/"out"/"scratch")
+    test("pathUp") {
+      val target = os.root / "out" / "scratch" / "file"
+      assert(target / os.up == os.root / "out" / "scratch")
     }
-    test("relPathUp"){
-      val target = os.rel/"out"/"scratch"/"file"
-      assert(target/os.up == os.rel/"out"/"scratch")
+    test("relPathUp") {
+      val target = os.rel / "out" / "scratch" / "file"
+      assert(target / os.up == os.rel / "out" / "scratch")
     }
-    test("relPathUp"){
-      val target = os.sub/"out"/"scratch"/"file"
-      assert(target/os.up == os.sub/"out"/"scratch")
+    test("relPathUp") {
+      val target = os.sub / "out" / "scratch" / "file"
+      assert(target / os.up == os.sub / "out" / "scratch")
     }
-    test("canonical"){if (Unix()){
+    test("canonical") {
+      if (Unix()) {
 
-      assert((os.root/"folder"/"file"/os.up).toString == "/folder")
-      // not "/folder/file/.."
+        assert((os.root / "folder" / "file" / os.up).toString == "/folder")
+        // not "/folder/file/.."
 
-      assert((os.rel/"folder"/"file"/os.up).toString == "folder")
-      // not "folder/file/.."
-    }}
-    test("findWc"){
+        assert((os.rel / "folder" / "file" / os.up).toString == "folder")
+        // not "folder/file/.."
+      }
+    }
+    test("findWc") {
 
-      val wd = os.pwd/"os"/"test"/"resources"/"test"
+      val wd = os.pwd / "os" / "test" / "resources" / "test"
 
       // find . -name '*.txt' | xargs wc -l
       val lines = os.walk(wd)
@@ -253,14 +266,14 @@ object ExampleTests extends TestSuite{
       assert(lines == 9)
     }
 
-    test("rename"){
+    test("rename") {
 //      val d1/"omg"/x1 = wd
 //      val d2/"omg"/x2 = wd
 //      ls! wd |? (_.ext == "scala") | (x => mv! x ! x.pref)
     }
-    test("allSubpathsResolveCorrectly"){
+    test("allSubpathsResolveCorrectly") {
 
-      for(abs <- os.walk(os.pwd)){
+      for (abs <- os.walk(os.pwd)) {
         val rel = abs.relativeTo(os.pwd)
         assert(rel.ups == 0)
         assert(os.pwd / rel == abs)

--- a/os/test/src-jvm/FilesystemMetadataTests.scala
+++ b/os/test/src-jvm/FilesystemMetadataTests.scala
@@ -8,9 +8,9 @@ object FilesystemMetadataTests extends TestSuite {
   // on unix it is 81 bytes, win adds 3 bytes (3 \r characters)
   private val multilineSizes = Set[Long](81, 84)
 
-  def tests = Tests{
-    test("stat"){
-      test - prep{ wd =>
+  def tests = Tests {
+    test("stat") {
+      test - prep { wd =>
         os.stat(wd / "File.txt").size ==> 8
         assert(multilineSizes contains os.stat(wd / "Multi Line.txt").size)
         os.stat(wd / "folder1").fileType ==> os.FileType.Dir
@@ -23,8 +23,8 @@ object FilesystemMetadataTests extends TestSuite {
 //        }
 //      }
     }
-    test("isFile"){
-      test - prep{ wd =>
+    test("isFile") {
+      test - prep { wd =>
         os.isFile(wd / "File.txt") ==> true
         os.isFile(wd / "folder1") ==> false
 
@@ -33,8 +33,8 @@ object FilesystemMetadataTests extends TestSuite {
         os.isFile(wd / "misc" / "file-symlink", followLinks = false) ==> false
       }
     }
-    test("isDir"){
-      test - prep{ wd =>
+    test("isDir") {
+      test - prep { wd =>
         os.isDir(wd / "File.txt") ==> false
         os.isDir(wd / "folder1") ==> true
 
@@ -43,21 +43,21 @@ object FilesystemMetadataTests extends TestSuite {
         os.isDir(wd / "misc" / "folder-symlink", followLinks = false) ==> false
       }
     }
-    test("isLink"){
-      test - prep{ wd =>
+    test("isLink") {
+      test - prep { wd =>
         os.isLink(wd / "misc" / "file-symlink") ==> true
         os.isLink(wd / "misc" / "folder-symlink") ==> true
         os.isLink(wd / "folder1") ==> false
       }
     }
-    test("size"){
-      test - prep{ wd =>
+    test("size") {
+      test - prep { wd =>
         os.size(wd / "File.txt") ==> 8
         assert(multilineSizes contains os.size(wd / "Multi Line.txt"))
       }
     }
-    test("mtime"){
-      test - prep{ wd =>
+    test("mtime") {
+      test - prep { wd =>
         os.mtime.set(wd / "File.txt", 0)
         os.mtime(wd / "File.txt") ==> 0
 

--- a/os/test/src-jvm/FilesystemPermissionsTests.scala
+++ b/os/test/src-jvm/FilesystemPermissionsTests.scala
@@ -4,45 +4,51 @@ import test.os.TestUtil.prep
 import utest._
 
 object FilesystemPermissionsTests extends TestSuite {
-  def tests = Tests{
-    test("perms"){
-      test - prep { wd => if (Unix()){
-        os.perms.set(wd / "File.txt", "rwxrwxrwx")
-        os.perms(wd / "File.txt").toString() ==> "rwxrwxrwx"
-        os.perms(wd / "File.txt").toInt() ==> Integer.parseInt("777", 8)
+  def tests = Tests {
+    test("perms") {
+      test - prep { wd =>
+        if (Unix()) {
+          os.perms.set(wd / "File.txt", "rwxrwxrwx")
+          os.perms(wd / "File.txt").toString() ==> "rwxrwxrwx"
+          os.perms(wd / "File.txt").toInt() ==> Integer.parseInt("777", 8)
 
-        os.perms.set(wd / "File.txt", Integer.parseInt("755", 8))
-        os.perms(wd / "File.txt").toString() ==> "rwxr-xr-x"
+          os.perms.set(wd / "File.txt", Integer.parseInt("755", 8))
+          os.perms(wd / "File.txt").toString() ==> "rwxr-xr-x"
 
-        os.perms.set(wd / "File.txt", "r-xr-xr-x")
-        os.perms.set(wd / "File.txt", Integer.parseInt("555", 8))
-      }}
-    }
-    test("owner"){
-      test - prep { wd => if (Unix()){
-        // Only works as root :(
-        if(false){
-          val originalOwner = os.owner(wd / "File.txt")
-
-          os.owner.set(wd / "File.txt", "nobody")
-          os.owner(wd / "File.txt").getName ==> "nobody"
-
-          os.owner.set(wd / "File.txt", originalOwner)
+          os.perms.set(wd / "File.txt", "r-xr-xr-x")
+          os.perms.set(wd / "File.txt", Integer.parseInt("555", 8))
         }
-      }}
+      }
     }
-    test("group"){
-      test - prep { wd => if (Unix()){
-        // Only works as root :(
-        if (false){
-          val originalOwner = os.owner(wd / "File.txt")
+    test("owner") {
+      test - prep { wd =>
+        if (Unix()) {
+          // Only works as root :(
+          if (false) {
+            val originalOwner = os.owner(wd / "File.txt")
 
-          os.owner.set(wd / "File.txt", "nobody")
-          os.owner(wd / "File.txt").getName ==> "nobody"
+            os.owner.set(wd / "File.txt", "nobody")
+            os.owner(wd / "File.txt").getName ==> "nobody"
 
-          os.owner.set(wd / "File.txt", originalOwner)
+            os.owner.set(wd / "File.txt", originalOwner)
+          }
         }
-      }}
+      }
+    }
+    test("group") {
+      test - prep { wd =>
+        if (Unix()) {
+          // Only works as root :(
+          if (false) {
+            val originalOwner = os.owner(wd / "File.txt")
+
+            os.owner.set(wd / "File.txt", "nobody")
+            os.owner(wd / "File.txt").getName ==> "nobody"
+
+            os.owner.set(wd / "File.txt", originalOwner)
+          }
+        }
+      }
     }
   }
 }

--- a/os/test/src-jvm/ListingWalkingTests.scala
+++ b/os/test/src-jvm/ListingWalkingTests.scala
@@ -4,9 +4,9 @@ import test.os.TestUtil.prep
 import utest._
 
 object ListingWalkingTests extends TestSuite {
-  def tests = Tests{
-    test("list"){
-      test - prep{ wd =>
+  def tests = Tests {
+    test("list") {
+      test - prep { wd =>
         os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
         os.list(wd / "folder2") ==> Seq(
           wd / "folder2" / "nestedA",
@@ -17,19 +17,19 @@ object ListingWalkingTests extends TestSuite {
           wd / "misc" / "folder-symlink" / "one.txt"
         )
       }
-      test("stream"){
-        test - prep{ wd =>
+      test("stream") {
+        test - prep { wd =>
           os.list.stream(wd / "folder2").count() ==> 2
 
           // Streaming the listed files to the console
-          for(line <- os.list.stream(wd / "folder2")){
+          for (line <- os.list.stream(wd / "folder2")) {
             println(line)
           }
         }
       }
     }
-    test("walk"){
-      test - prep{ wd =>
+    test("walk") {
+      test - prep { wd =>
         os.walk(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
 
         os.walk(wd / "folder1", includeTarget = true) ==> Seq(
@@ -65,33 +65,35 @@ object ListingWalkingTests extends TestSuite {
           wd / "misc" / "folder-symlink" / "one.txt"
         )
       }
-      test("attrs"){
-        test - prep{ wd => if(Unix()){
-          val filesSortedBySize = os.walk.attrs(wd / "misc", followLinks = true)
-            .sortBy{case (p, attrs) => attrs.size}
-            .collect{case (p, attrs) if attrs.isFile => p}
+      test("attrs") {
+        test - prep { wd =>
+          if (Unix()) {
+            val filesSortedBySize = os.walk.attrs(wd / "misc", followLinks = true)
+              .sortBy { case (p, attrs) => attrs.size }
+              .collect { case (p, attrs) if attrs.isFile => p }
 
-          filesSortedBySize ==> Seq(
-            wd / "misc" / "echo",
-            wd / "misc" / "file-symlink",
-            wd / "misc" / "echo_with_wd",
-            wd / "misc" / "folder-symlink" / "one.txt",
-            wd / "misc" / "binary.png"
-          )
-        }}
+            filesSortedBySize ==> Seq(
+              wd / "misc" / "echo",
+              wd / "misc" / "file-symlink",
+              wd / "misc" / "echo_with_wd",
+              wd / "misc" / "folder-symlink" / "one.txt",
+              wd / "misc" / "binary.png"
+            )
+          }
+        }
       }
-      test("stream"){
-        test - prep{ wd =>
+      test("stream") {
+        test - prep { wd =>
           os.walk.stream(wd / "folder1").count() ==> 1
 
           os.walk.stream(wd / "folder2").count() ==> 4
 
           os.walk.stream(wd / "folder2", skip = _.last == "nestedA").count() ==> 2
         }
-        test("attrs"){
-          test - prep{ wd =>
+        test("attrs") {
+          test - prep { wd =>
             def totalFileSizes(p: os.Path) = os.walk.stream.attrs(p)
-              .collect{case (p, attrs) if attrs.isFile => attrs.size}
+              .collect { case (p, attrs) if attrs.isFile => attrs.size }
               .sum
 
             totalFileSizes(wd / "folder1") ==> 22

--- a/os/test/src-jvm/ManipulatingFilesFoldersTests.scala
+++ b/os/test/src-jvm/ManipulatingFilesFoldersTests.scala
@@ -4,9 +4,9 @@ import test.os.TestUtil.prep
 import utest._
 
 object ManipulatingFilesFoldersTests extends TestSuite {
-  def tests = Tests{
-    test("exists"){
-      test - prep{ wd =>
+  def tests = Tests {
+    test("exists") {
+      test - prep { wd =>
         os.exists(wd / "File.txt") ==> true
         os.exists(wd / "folder1") ==> true
         os.exists(wd / "doesnt-exist") ==> false
@@ -17,8 +17,8 @@ object ManipulatingFilesFoldersTests extends TestSuite {
         os.exists(wd / "misc" / "broken-symlink", followLinks = false) ==> true
       }
     }
-    test("move"){
-      test - prep{ wd =>
+    test("move") {
+      test - prep { wd =>
         os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
         os.move(wd / "folder1" / "one.txt", wd / "folder1" / "first.txt")
         os.list(wd / "folder1") ==> Seq(wd / "folder1" / "first.txt")
@@ -35,8 +35,8 @@ object ManipulatingFilesFoldersTests extends TestSuite {
             |I weigh twice as much as you
             |And I look good on the barbecue""".stripMargin
       }
-      test("matching"){
-        test - prep{ wd =>
+      test("matching") {
+        test - prep { wd =>
           import os.{GlobSyntax, /}
           os.walk(wd / "folder2").toSet ==> Set(
             wd / "folder2" / "nestedA",
@@ -45,7 +45,7 @@ object ManipulatingFilesFoldersTests extends TestSuite {
             wd / "folder2" / "nestedB" / "b.txt"
           )
 
-          os.walk(wd/"folder2").collect(os.move.matching{case p/g"$x.txt" => p/g"$x.data"})
+          os.walk(wd / "folder2").collect(os.move.matching { case p / g"$x.txt" => p / g"$x.data" })
 
           os.walk(wd / "folder2").toSet ==> Set(
             wd / "folder2" / "nestedA",
@@ -55,23 +55,23 @@ object ManipulatingFilesFoldersTests extends TestSuite {
           )
         }
       }
-      test("into"){
-        test - prep{ wd =>
+      test("into") {
+        test - prep { wd =>
           os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
           os.move.into(wd / "File.txt", wd / "folder1")
           os.list(wd / "folder1") ==> Seq(wd / "folder1" / "File.txt", wd / "folder1" / "one.txt")
         }
       }
-      test("over"){
-        test - prep{ wd =>
+      test("over") {
+        test - prep { wd =>
           os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedA", wd / "folder2" / "nestedB")
           os.move.over(wd / "folder1", wd / "folder2")
           os.list(wd / "folder2") ==> Seq(wd / "folder2" / "one.txt")
         }
       }
     }
-    test("copy"){
-      test - prep{ wd =>
+    test("copy") {
+      test - prep { wd =>
         os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
         os.copy(wd / "folder1" / "one.txt", wd / "folder1" / "first.txt")
         os.list(wd / "folder1") ==> Seq(wd / "folder1" / "first.txt", wd / "folder1" / "one.txt")
@@ -92,15 +92,15 @@ object ManipulatingFilesFoldersTests extends TestSuite {
             |I weigh twice as much as you
             |And I look good on the barbecue""".stripMargin
       }
-      test("into"){
-        test - prep{ wd =>
+      test("into") {
+        test - prep { wd =>
           os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
           os.copy.into(wd / "File.txt", wd / "folder1")
           os.list(wd / "folder1") ==> Seq(wd / "folder1" / "File.txt", wd / "folder1" / "one.txt")
         }
       }
-      test("over"){
-        test - prep{ wd =>
+      test("over") {
+        test - prep { wd =>
           os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedA", wd / "folder2" / "nestedB")
           os.copy.over(wd / "folder1", wd / "folder2")
           os.list(wd / "folder2") ==> Seq(wd / "folder2" / "one.txt")
@@ -108,7 +108,7 @@ object ManipulatingFilesFoldersTests extends TestSuite {
       }
       test("symlinks") {
         val src = os.temp.dir(deleteOnExit = true)
-        
+
         os.makeDir(src / "t0")
         os.write(src / "t0" / "file", "hello")
         os.symlink(src / "t1", os.rel / "t0")
@@ -149,22 +149,22 @@ object ManipulatingFilesFoldersTests extends TestSuite {
         }
       }
     }
-    test("makeDir"){
-      test - prep{ wd =>
+    test("makeDir") {
+      test - prep { wd =>
         os.exists(wd / "new_folder") ==> false
         os.makeDir(wd / "new_folder")
         os.exists(wd / "new_folder") ==> true
       }
-      test("all"){
-        test - prep{ wd =>
+      test("all") {
+        test - prep { wd =>
           os.exists(wd / "new_folder") ==> false
           os.makeDir.all(wd / "new_folder" / "inner" / "deep")
           os.exists(wd / "new_folder" / "inner" / "deep") ==> true
         }
       }
     }
-    test("remove"){
-      test - prep{ wd =>
+    test("remove") {
+      test - prep { wd =>
         os.exists(wd / "File.txt") ==> true
         os.remove(wd / "File.txt")
         os.exists(wd / "File.txt") ==> false
@@ -175,8 +175,8 @@ object ManipulatingFilesFoldersTests extends TestSuite {
         os.exists(wd / "folder1" / "one.txt") ==> false
         os.exists(wd / "folder1") ==> false
       }
-      test("link"){
-        test - prep{ wd =>
+      test("link") {
+        test - prep { wd =>
           os.remove(wd / "misc" / "file-symlink")
           os.exists(wd / "misc" / "file-symlink", followLinks = false) ==> false
           os.exists(wd / "File.txt", followLinks = false) ==> true
@@ -190,15 +190,15 @@ object ManipulatingFilesFoldersTests extends TestSuite {
           os.exists(wd / "misc" / "broken-symlink", followLinks = false) ==> false
         }
       }
-      test("all"){
-        test - prep{ wd =>
+      test("all") {
+        test - prep { wd =>
           os.exists(wd / "folder1" / "one.txt") ==> true
           os.remove.all(wd / "folder1")
           os.exists(wd / "folder1" / "one.txt") ==> false
           os.exists(wd / "folder1") ==> false
         }
-        test("link"){
-          test - prep{ wd =>
+        test("link") {
+          test - prep { wd =>
             os.remove.all(wd / "misc" / "file-symlink")
             os.exists(wd / "misc" / "file-symlink", followLinks = false) ==> false
             os.exists(wd / "File.txt", followLinks = false) ==> true
@@ -214,16 +214,16 @@ object ManipulatingFilesFoldersTests extends TestSuite {
         }
       }
     }
-    test("hardlink"){
-      test - prep{ wd =>
+    test("hardlink") {
+      test - prep { wd =>
         os.hardlink(wd / "Linked.txt", wd / "File.txt")
         os.exists(wd / "Linked.txt")
         os.read(wd / "Linked.txt") ==> "I am cow"
         os.isLink(wd / "Linked.txt") ==> false
       }
     }
-    test("symlink"){
-      test - prep{ wd =>
+    test("symlink") {
+      test - prep { wd =>
         os.symlink(wd / "Linked.txt", wd / "File.txt")
         os.exists(wd / "Linked.txt")
         os.read(wd / "Linked.txt") ==> "I am cow"
@@ -235,35 +235,37 @@ object ManipulatingFilesFoldersTests extends TestSuite {
         os.isLink(wd / "Linked2.txt") ==> true
       }
     }
-    test("followLink"){
-      test - prep{ wd =>
+    test("followLink") {
+      test - prep { wd =>
         os.followLink(wd / "misc" / "file-symlink") ==> Some(wd / "File.txt")
         os.followLink(wd / "misc" / "folder-symlink") ==> Some(wd / "folder1")
         os.followLink(wd / "misc" / "broken-symlink") ==> None
       }
     }
-    test("readLink"){
-      test - prep{ wd =>  if(Unix()){
-        os.readLink(wd / "misc" / "file-symlink") ==> os.up / "File.txt"
-        os.readLink(wd / "misc" / "folder-symlink") ==> os.up / "folder1"
-        os.readLink(wd / "misc" / "broken-symlink") ==> os.rel / "broken"
-        os.readLink(wd / "misc" / "broken-abs-symlink") ==> os.root / "doesnt" / "exist"
+    test("readLink") {
+      test - prep { wd =>
+        if (Unix()) {
+          os.readLink(wd / "misc" / "file-symlink") ==> os.up / "File.txt"
+          os.readLink(wd / "misc" / "folder-symlink") ==> os.up / "folder1"
+          os.readLink(wd / "misc" / "broken-symlink") ==> os.rel / "broken"
+          os.readLink(wd / "misc" / "broken-abs-symlink") ==> os.root / "doesnt" / "exist"
 
-        os.readLink.absolute(wd / "misc" / "file-symlink") ==> wd / "File.txt"
-        os.readLink.absolute(wd / "misc" / "folder-symlink") ==> wd / "folder1"
-        os.readLink.absolute(wd / "misc" / "broken-symlink") ==> wd / "misc" / "broken"
-        os.readLink.absolute(wd / "misc" / "broken-abs-symlink") ==> os.root / "doesnt" / "exist"
-      }}
+          os.readLink.absolute(wd / "misc" / "file-symlink") ==> wd / "File.txt"
+          os.readLink.absolute(wd / "misc" / "folder-symlink") ==> wd / "folder1"
+          os.readLink.absolute(wd / "misc" / "broken-symlink") ==> wd / "misc" / "broken"
+          os.readLink.absolute(wd / "misc" / "broken-abs-symlink") ==> os.root / "doesnt" / "exist"
+        }
+      }
     }
-    test("temp"){
-      test - prep{ wd =>
+    test("temp") {
+      test - prep { wd =>
         val tempOne = os.temp("default content")
         os.read(tempOne) ==> "default content"
         os.write.over(tempOne, "Hello")
         os.read(tempOne) ==> "Hello"
       }
-      test("dir"){
-        test - prep{ wd =>
+      test("dir") {
+        test - prep { wd =>
           val tempDir = os.temp.dir()
           os.list(tempDir) ==> Nil
           os.write(tempDir / "file", "Hello")

--- a/os/test/src-jvm/OpTestsJvmOnly.scala
+++ b/os/test/src-jvm/OpTestsJvmOnly.scala
@@ -3,187 +3,190 @@ package test.os
 import java.nio.file.NoSuchFileException
 import java.nio.{file => nio}
 
-
 import utest._
 import os.{GlobSyntax, /}
 import java.nio.charset.Charset
 
-object OpTestsJvmOnly extends TestSuite{
+object OpTestsJvmOnly extends TestSuite {
 
   val tests = Tests {
-    val res = os.pwd/"os"/"test"/"resources"/"test"
+    val res = os.pwd / "os" / "test" / "resources" / "test"
 
-    test("lsR"){
+    test("lsR") {
       os.walk(res).foreach(println)
-      intercept[java.nio.file.NoSuchFileException](os.walk(os.pwd/"out"/"scratch"/"nonexistent"))
+      intercept[java.nio.file.NoSuchFileException](
+        os.walk(os.pwd / "out" / "scratch" / "nonexistent")
+      )
       assert(
-        os.walk(res/"folder2"/"nestedB") == Seq(res/"folder2"/"nestedB"/"b.txt"),
-        os.walk(res/"folder2").toSet == Set(
-          res/"folder2"/"nestedA",
-          res/"folder2"/"nestedA"/"a.txt",
-          res/"folder2"/"nestedB",
-          res/"folder2"/"nestedB"/"b.txt"
+        os.walk(res / "folder2" / "nestedB") == Seq(res / "folder2" / "nestedB" / "b.txt"),
+        os.walk(res / "folder2").toSet == Set(
+          res / "folder2" / "nestedA",
+          res / "folder2" / "nestedA" / "a.txt",
+          res / "folder2" / "nestedB",
+          res / "folder2" / "nestedB" / "b.txt"
         )
       )
     }
-    test("lsRecPermissions"){
-      if(Unix()){
-        assert(os.walk(os.root/"var"/"run").nonEmpty)
+    test("lsRecPermissions") {
+      if (Unix()) {
+        assert(os.walk(os.root / "var" / "run").nonEmpty)
       }
     }
-    test("readResource"){
-      test("positive"){
-        test("absolute"){
-          val contents = os.read(os.resource/"test"/"os"/"folder"/"file.txt")
+    test("readResource") {
+      test("positive") {
+        test("absolute") {
+          val contents = os.read(os.resource / "test" / "os" / "folder" / "file.txt")
           assert(contents.contains("file contents lols"))
 
           val cl = getClass.getClassLoader
-          val contents2 = os.read(os.resource(cl)/"test"/"os"/"folder"/"file.txt")
+          val contents2 = os.read(os.resource(cl) / "test" / "os" / "folder" / "file.txt")
           assert(contents2.contains("file contents lols"))
         }
 
-        test("relative"){
+        test("relative") {
           val cls = classOf[_root_.test.os.Testing]
-          val contents = os.read(os.resource(cls)/"folder"/"file.txt")
+          val contents = os.read(os.resource(cls) / "folder" / "file.txt")
           assert(contents.contains("file contents lols"))
 
-          val contents2 = os.read(os.resource(getClass)/"folder"/"file.txt")
+          val contents2 = os.read(os.resource(getClass) / "folder" / "file.txt")
           assert(contents2.contains("file contents lols"))
         }
       }
-      test("negative"){
-        test - intercept[os.ResourceNotFoundException]{
-          os.read(os.resource/"folder"/"file.txt")
+      test("negative") {
+        test - intercept[os.ResourceNotFoundException] {
+          os.read(os.resource / "folder" / "file.txt")
         }
 
-        test - intercept[os.ResourceNotFoundException]{
-          os.read(os.resource(classOf[_root_.test.os.Testing])/"test"/"os"/"folder"/"file.txt")
+        test - intercept[os.ResourceNotFoundException] {
+          os.read(
+            os.resource(classOf[_root_.test.os.Testing]) / "test" / "os" / "folder" / "file.txt"
+          )
         }
-        test - intercept[os.ResourceNotFoundException]{
-          os.read(os.resource(getClass)/"test"/"os"/"folder"/"file.txt")
+        test - intercept[os.ResourceNotFoundException] {
+          os.read(os.resource(getClass) / "test" / "os" / "folder" / "file.txt")
         }
-        test - intercept[os.ResourceNotFoundException]{
-          os.read(os.resource(getClass.getClassLoader)/"folder"/"file.txt")
+        test - intercept[os.ResourceNotFoundException] {
+          os.read(os.resource(getClass.getClassLoader) / "folder" / "file.txt")
         }
       }
     }
-    test("Mutating"){
-      val testFolder = os.pwd/"out"/"scratch"/"test"
+    test("Mutating") {
+      val testFolder = os.pwd / "out" / "scratch" / "test"
       os.remove.all(testFolder)
       os.makeDir.all(testFolder)
-      test("cp"){
-        val d = testFolder/"copying"
-        test("basic"){
+      test("cp") {
+        val d = testFolder / "copying"
+        test("basic") {
           assert(
-            !os.exists(d/"folder"),
-            !os.exists(d/"file")
+            !os.exists(d / "folder"),
+            !os.exists(d / "file")
           )
-          os.makeDir.all(d/"folder")
-          os.write(d/"file", "omg")
+          os.makeDir.all(d / "folder")
+          os.write(d / "file", "omg")
           assert(
-            os.exists(d/"folder"),
-            os.exists(d/"file"),
-            os.read(d/"file") == "omg"
+            os.exists(d / "folder"),
+            os.exists(d / "file"),
+            os.read(d / "file") == "omg"
           )
-          os.copy(d/"folder", d/"folder2")
-          os.copy(d/"file", d/"file2")
+          os.copy(d / "folder", d / "folder2")
+          os.copy(d / "file", d / "file2")
 
           assert(
-            os.exists(d/"folder"),
-            os.exists(d/"file"),
-            os.read(d/"file") == "omg",
-            os.exists(d/"folder2"),
-            os.exists(d/"file2"),
-            os.read(d/"file2") == "omg"
+            os.exists(d / "folder"),
+            os.exists(d / "file"),
+            os.read(d / "file") == "omg",
+            os.exists(d / "folder2"),
+            os.exists(d / "file2"),
+            os.read(d / "file2") == "omg"
           )
         }
-        test("deep"){
-          os.write(d/"folderA"/"folderB"/"file", "Cow", createFolders = true)
-          os.copy(d/"folderA", d/"folderC")
-          assert(os.read(d/"folderC"/"folderB"/"file") == "Cow")
+        test("deep") {
+          os.write(d / "folderA" / "folderB" / "file", "Cow", createFolders = true)
+          os.copy(d / "folderA", d / "folderC")
+          assert(os.read(d / "folderC" / "folderB" / "file") == "Cow")
         }
-        test("merging"){
-          val mergeDir = d/"merge"
-          os.write(mergeDir/"folderA"/"folderB"/"file", "Cow", createFolders = true)
-          os.write(mergeDir/"folderC"/"file", "moo", createFolders = true)
-          os.copy(mergeDir/"folderA", mergeDir/"folderC", mergeFolders = true)
-          assert(os.read(mergeDir/"folderC"/"folderB"/"file") == "Cow")
-          assert(os.read(mergeDir/"folderC"/"file") == "moo")
+        test("merging") {
+          val mergeDir = d / "merge"
+          os.write(mergeDir / "folderA" / "folderB" / "file", "Cow", createFolders = true)
+          os.write(mergeDir / "folderC" / "file", "moo", createFolders = true)
+          os.copy(mergeDir / "folderA", mergeDir / "folderC", mergeFolders = true)
+          assert(os.read(mergeDir / "folderC" / "folderB" / "file") == "Cow")
+          assert(os.read(mergeDir / "folderC" / "file") == "moo")
         }
       }
-      test("mv"){
-        test("basic"){
-          val d = testFolder/"moving"
-          os.makeDir.all(d/"folder")
-          assert(os.list(d) == Seq(d/"folder"))
-          os.move(d/"folder", d/"folder2")
-          assert(os.list(d) == Seq(d/"folder2"))
+      test("mv") {
+        test("basic") {
+          val d = testFolder / "moving"
+          os.makeDir.all(d / "folder")
+          assert(os.list(d) == Seq(d / "folder"))
+          os.move(d / "folder", d / "folder2")
+          assert(os.list(d) == Seq(d / "folder2"))
         }
-        test("shallow"){
-          val d = testFolder/"moving2"
+        test("shallow") {
+          val d = testFolder / "moving2"
           os.makeDir(d)
-          os.write(d/"A.scala", "AScala")
-          os.write(d/"B.scala", "BScala")
-          os.write(d/"A.py", "APy")
-          os.write(d/"B.py", "BPy")
+          os.write(d / "A.scala", "AScala")
+          os.write(d / "B.scala", "BScala")
+          os.write(d / "A.py", "APy")
+          os.write(d / "B.py", "BPy")
           def fileSet = os.list(d).map(_.last).toSet
           assert(fileSet == Set("A.scala", "B.scala", "A.py", "B.py"))
-          test("partialMoves"){
-            os.list(d).collect(os.move.matching{case p/g"$x.scala" => p/g"$x.java"})
+          test("partialMoves") {
+            os.list(d).collect(os.move.matching { case p / g"$x.scala" => p / g"$x.java" })
             assert(fileSet == Set("A.java", "B.java", "A.py", "B.py"))
-            os.list(d).collect(os.move.matching{case p/g"A.$x" => p/g"C.$x"})
+            os.list(d).collect(os.move.matching { case p / g"A.$x" => p / g"C.$x" })
             assert(fileSet == Set("C.java", "B.java", "C.py", "B.py"))
           }
-          test("fullMoves"){
-            os.list(d).map(os.move.matching{case p/g"$x.$y" => p/g"$y.$x"})
+          test("fullMoves") {
+            os.list(d).map(os.move.matching { case p / g"$x.$y" => p / g"$y.$x" })
             assert(fileSet == Set("scala.A", "scala.B", "py.A", "py.B"))
-            def die = os.list(d).map(os.move.matching{case p/g"A.$x" => p/g"C.$x"})
-            intercept[MatchError]{ die }
+            def die = os.list(d).map(os.move.matching { case p / g"A.$x" => p / g"C.$x" })
+            intercept[MatchError] { die }
           }
         }
 
-        test("deep"){
-          val d = testFolder/"moving2"
+        test("deep") {
+          val d = testFolder / "moving2"
           os.makeDir(d)
-          os.makeDir(d/"scala")
-          os.write(d/"scala"/"A", "AScala")
-          os.write(d/"scala"/"B", "BScala")
-          os.makeDir(d/"py")
-          os.write(d/"py"/"A", "APy")
-          os.write(d/"py"/"B", "BPy")
-          test("partialMoves"){
-            os.walk(d).collect(os.move.matching{case d/"py"/x => d/x })
+          os.makeDir(d / "scala")
+          os.write(d / "scala" / "A", "AScala")
+          os.write(d / "scala" / "B", "BScala")
+          os.makeDir(d / "py")
+          os.write(d / "py" / "A", "APy")
+          os.write(d / "py" / "B", "BPy")
+          test("partialMoves") {
+            os.walk(d).collect(os.move.matching { case d / "py" / x => d / x })
             assert(
               os.walk(d).toSet == Set(
-                d/"py",
-                d/"scala",
-                d/"scala"/"A",
-                d/"scala"/"B",
-                d/"A",
-                d/"B"
+                d / "py",
+                d / "scala",
+                d / "scala" / "A",
+                d / "scala" / "B",
+                d / "A",
+                d / "B"
               )
             )
           }
-          test("fullMoves"){
-            def die = os.walk(d).map(os.move.matching{case d/"py"/x => d/x })
-            intercept[MatchError]{ die }
+          test("fullMoves") {
+            def die = os.walk(d).map(os.move.matching { case d / "py" / x => d / x })
+            intercept[MatchError] { die }
 
-            os.walk(d).filter(os.isFile).map(os.move.matching{
-              case d/"py"/x => d/"scala"/"py"/x
-              case d/"scala"/x => d/"py"/"scala"/x
+            os.walk(d).filter(os.isFile).map(os.move.matching {
+              case d / "py" / x => d / "scala" / "py" / x
+              case d / "scala" / x => d / "py" / "scala" / x
               case d => println("NOT FOUND " + d); d
             })
 
             assert(
               os.walk(d).toSet == Set(
-                d/"py",
-                d/"scala",
-                d/"py"/"scala",
-                d/"scala"/"py",
-                d/"scala"/"py"/"A",
-                d/"scala"/"py"/"B",
-                d/"py"/"scala"/"A",
-                d/"py"/"scala"/"B"
+                d / "py",
+                d / "scala",
+                d / "py" / "scala",
+                d / "scala" / "py",
+                d / "scala" / "py" / "A",
+                d / "scala" / "py" / "B",
+                d / "py" / "scala" / "A",
+                d / "py" / "scala" / "B"
               )
             )
           }
@@ -191,84 +194,87 @@ object OpTestsJvmOnly extends TestSuite{
         //          ls! wd | mv*
       }
 
-      test("mkdirRm"){
-        test("singleFolder"){
-          val single = testFolder/"single"
-          os.makeDir.all(single/"inner")
-          assert(os.list(single) == Seq(single/"inner"))
-          os.remove(single/"inner")
+      test("mkdirRm") {
+        test("singleFolder") {
+          val single = testFolder / "single"
+          os.makeDir.all(single / "inner")
+          assert(os.list(single) == Seq(single / "inner"))
+          os.remove(single / "inner")
           assert(os.list(single) == Seq())
         }
-        test("nestedFolders"){
-          val nested = testFolder/"nested"
-          os.makeDir.all(nested/"inner"/"innerer"/"innerest")
+        test("nestedFolders") {
+          val nested = testFolder / "nested"
+          os.makeDir.all(nested / "inner" / "innerer" / "innerest")
           assert(
-            os.list(nested) == Seq(nested/"inner"),
-            os.list(nested/"inner") == Seq(nested/"inner"/"innerer"),
-            os.list(nested/"inner"/"innerer") == Seq(nested/"inner"/"innerer"/"innerest")
+            os.list(nested) == Seq(nested / "inner"),
+            os.list(nested / "inner") == Seq(nested / "inner" / "innerer"),
+            os.list(nested / "inner" / "innerer") == Seq(nested / "inner" / "innerer" / "innerest")
           )
-          os.remove.all(nested/"inner")
+          os.remove.all(nested / "inner")
           assert(os.list(nested) == Seq())
         }
       }
 
-      test("readWrite"){
-        val d = testFolder/"readWrite"
+      test("readWrite") {
+        val d = testFolder / "readWrite"
         os.makeDir.all(d)
-        test("simple"){
-          os.write(d/"file", "i am a cow")
-          assert(os.read(d/"file") == "i am a cow")
+        test("simple") {
+          os.write(d / "file", "i am a cow")
+          assert(os.read(d / "file") == "i am a cow")
         }
-        test("autoMkdir"){
-          os.write(d/"folder"/"folder"/"file", "i am a cow", createFolders = true)
-          assert(os.read(d/"folder"/"folder"/"file") == "i am a cow")
+        test("autoMkdir") {
+          os.write(d / "folder" / "folder" / "file", "i am a cow", createFolders = true)
+          assert(os.read(d / "folder" / "folder" / "file") == "i am a cow")
         }
-        test("binary"){
-          os.write(d/"file", Array[Byte](1, 2, 3, 4))
-          assert(os.read(d/"file").toSeq == Array[Byte](1, 2, 3, 4).toSeq)
+        test("binary") {
+          os.write(d / "file", Array[Byte](1, 2, 3, 4))
+          assert(os.read(d / "file").toSeq == Array[Byte](1, 2, 3, 4).toSeq)
         }
-        test("concatenating"){
-          os.write(d/"concat1", Seq("a", "b", "c"))
-          assert(os.read(d/"concat1") == "abc")
-          os.write(d/"concat2", Seq(Array[Byte](1, 2), Array[Byte](3, 4)))
-          assert(os.read.bytes(d/"concat2").toSeq == Array[Byte](1, 2, 3, 4).toSeq)
-          os.write(d/"concat3", geny.Generator(Array[Byte](1, 2), Array[Byte](3, 4)))
-          assert(os.read.bytes(d/"concat3").toSeq == Array[Byte](1, 2, 3, 4).toSeq)
+        test("concatenating") {
+          os.write(d / "concat1", Seq("a", "b", "c"))
+          assert(os.read(d / "concat1") == "abc")
+          os.write(d / "concat2", Seq(Array[Byte](1, 2), Array[Byte](3, 4)))
+          assert(os.read.bytes(d / "concat2").toSeq == Array[Byte](1, 2, 3, 4).toSeq)
+          os.write(d / "concat3", geny.Generator(Array[Byte](1, 2), Array[Byte](3, 4)))
+          assert(os.read.bytes(d / "concat3").toSeq == Array[Byte](1, 2, 3, 4).toSeq)
         }
-        test("writeAppend"){
-          os.write.append(d/"append.txt", "Hello")
-          assert(os.read(d/"append.txt") == "Hello")
-          os.write.append(d/"append.txt", " World")
-          assert(os.read(d/"append.txt") == "Hello World")
+        test("writeAppend") {
+          os.write.append(d / "append.txt", "Hello")
+          assert(os.read(d / "append.txt") == "Hello")
+          os.write.append(d / "append.txt", " World")
+          assert(os.read(d / "append.txt") == "Hello World")
         }
-        test("writeOver"){
-          os.write.over(d/"append.txt", "Hello")
-          assert(os.read(d/"append.txt") == "Hello")
-          os.write.over(d/"append.txt", " Wor")
-          assert(os.read(d/"append.txt") == " Wor")
+        test("writeOver") {
+          os.write.over(d / "append.txt", "Hello")
+          assert(os.read(d / "append.txt") == "Hello")
+          os.write.over(d / "append.txt", " Wor")
+          assert(os.read(d / "append.txt") == " Wor")
         }
         test("charset") {
-          os.write.over(d/"charset.txt", "funcionó".getBytes(Charset.forName("Windows-1252")))
-          assert(os.read.lines(d/"charset.txt", Charset.forName("Windows-1252")).head == "funcionó")
+          os.write.over(d / "charset.txt", "funcionó".getBytes(Charset.forName("Windows-1252")))
+          assert(os.read.lines(
+            d / "charset.txt",
+            Charset.forName("Windows-1252")
+          ).head == "funcionó")
         }
       }
 
-      test("Failures"){
-        val d = testFolder/"failures"
+      test("Failures") {
+        val d = testFolder / "failures"
         os.makeDir.all(d)
-        test("nonexistant"){
-          test - intercept[nio.NoSuchFileException](os.list(d/"nonexistent"))
-          test - intercept[nio.NoSuchFileException](os.read(d/"nonexistent"))
-          test - intercept[nio.NoSuchFileException](os.copy(d/"nonexistent", d/"yolo"))
-          test - intercept[nio.NoSuchFileException](os.move(d/"nonexistent", d/"yolo"))
+        test("nonexistant") {
+          test - intercept[nio.NoSuchFileException](os.list(d / "nonexistent"))
+          test - intercept[nio.NoSuchFileException](os.read(d / "nonexistent"))
+          test - intercept[nio.NoSuchFileException](os.copy(d / "nonexistent", d / "yolo"))
+          test - intercept[nio.NoSuchFileException](os.move(d / "nonexistent", d / "yolo"))
         }
-        test("collisions"){
-          os.makeDir.all(d/"folder")
-          os.write(d/"file", "lolol")
-          test - intercept[nio.FileAlreadyExistsException](os.move(d/"file", d/"folder"))
-          test - intercept[nio.FileAlreadyExistsException](os.copy(d/"file", d/"folder"))
-          test - intercept[nio.FileAlreadyExistsException](os.write(d/"file", "lols"))
-         }
+        test("collisions") {
+          os.makeDir.all(d / "folder")
+          os.write(d / "file", "lolol")
+          test - intercept[nio.FileAlreadyExistsException](os.move(d / "file", d / "folder"))
+          test - intercept[nio.FileAlreadyExistsException](os.copy(d / "file", d / "folder"))
+          test - intercept[nio.FileAlreadyExistsException](os.write(d / "file", "lols"))
+        }
       }
     }
   }

--- a/os/test/src-jvm/PathTestsJvmOnly.scala
+++ b/os/test/src-jvm/PathTestsJvmOnly.scala
@@ -4,40 +4,40 @@ import java.nio.file.Paths
 
 import os._
 import utest._
-object PathTestsJvmOnly extends TestSuite{
+object PathTestsJvmOnly extends TestSuite {
   val tests = Tests {
-    test("construction"){
-      test("symlinks"){
+    test("construction") {
+      test("symlinks") {
 
         val names = Seq("test123", "test124", "test125", "test126")
         val twd = temp.dir()
 
-        test("nestedSymlinks"){
-          if(Unix()) {
-            names.foreach(p => os.remove.all(twd/p))
-            os.makeDir.all(twd/"test123")
-            os.symlink(twd/"test124", twd/"test123")
-            os.symlink(twd/"test125", twd/"test124")
-            os.symlink(twd/"test126", twd/"test125")
-            assert(followLink(twd/"test126").get == followLink(twd/"test123").get)
-            names.foreach(p => os.remove(twd/p))
-            names.foreach(p => assert(!exists(twd/p)))
+        test("nestedSymlinks") {
+          if (Unix()) {
+            names.foreach(p => os.remove.all(twd / p))
+            os.makeDir.all(twd / "test123")
+            os.symlink(twd / "test124", twd / "test123")
+            os.symlink(twd / "test125", twd / "test124")
+            os.symlink(twd / "test126", twd / "test125")
+            assert(followLink(twd / "test126").get == followLink(twd / "test123").get)
+            names.foreach(p => os.remove(twd / p))
+            names.foreach(p => assert(!exists(twd / p)))
           }
         }
 
-        test("danglingSymlink"){
-          if(Unix()) {
-            names.foreach(p => os.remove.all(twd/p))
-            os.makeDir.all(twd/"test123")
-            os.symlink(twd/"test124", twd/"test123")
-            os.symlink(twd/"test125", twd/"test124")
-            os.symlink(twd/"test126", twd/"test125")
+        test("danglingSymlink") {
+          if (Unix()) {
+            names.foreach(p => os.remove.all(twd / p))
+            os.makeDir.all(twd / "test123")
+            os.symlink(twd / "test124", twd / "test123")
+            os.symlink(twd / "test125", twd / "test124")
+            os.symlink(twd / "test126", twd / "test125")
             os.remove(twd / "test123")
             assert(followLink(twd / "test126").isEmpty)
             names.foreach(p => os.remove.all(twd / p))
             names.foreach(p => assert(!exists(twd / p)))
-            names.foreach(p => os.remove.all(twd/p))
-            names.foreach(p => assert(!exists(twd/p)))
+            names.foreach(p => os.remove.all(twd / p))
+            names.foreach(p => assert(!exists(twd / p)))
           }
         }
       }

--- a/os/test/src-jvm/ReadingWritingTests.scala
+++ b/os/test/src-jvm/ReadingWritingTests.scala
@@ -2,9 +2,9 @@ package test.os
 import utest._
 import TestUtil._
 object ReadingWritingTests extends TestSuite {
-  def tests = Tests{
-    test("read"){
-      test - prep{ wd =>
+  def tests = Tests {
+    test("read") {
+      test - prep { wd =>
         os.read(wd / "File.txt") ==> "I am cow"
         os.read(wd / "folder1" / "one.txt") ==> "Contents of folder one"
         os.read(wd / "Multi Line.txt") ==>
@@ -13,8 +13,8 @@ object ReadingWritingTests extends TestSuite {
             |I weigh twice as much as you
             |And I look good on the barbecue""".stripMargin
       }
-      test("inputStream"){
-        test - prep{wd =>
+      test("inputStream") {
+        test - prep { wd =>
           val is = os.read.inputStream(wd / "File.txt") // ==> "I am cow"
           is.read() ==> 'I'
           is.read() ==> ' '
@@ -28,16 +28,16 @@ object ReadingWritingTests extends TestSuite {
           is.close()
         }
       }
-      test("bytes"){
-        test - prep{ wd =>
+      test("bytes") {
+        test - prep { wd =>
           os.read.bytes(wd / "File.txt") ==> "I am cow".getBytes
           os.read.bytes(wd / "misc" / "binary.png").length ==> 711
         }
       }
-      test("chunks"){
-        test - prep{ wd =>
+      test("chunks") {
+        test - prep { wd =>
           val chunks = os.read.chunks(wd / "File.txt", chunkSize = 2)
-            .map{case (buf, n) => buf.take(n).toSeq } // copy the buffer to save the data
+            .map { case (buf, n) => buf.take(n).toSeq } // copy the buffer to save the data
             .toSeq
 
           chunks ==> Seq(
@@ -49,8 +49,8 @@ object ReadingWritingTests extends TestSuite {
         }
       }
 
-      test("lines"){
-        test - prep{ wd =>
+      test("lines") {
+        test - prep { wd =>
           os.read.lines(wd / "File.txt") ==> Seq("I am cow")
           os.read.lines(wd / "Multi Line.txt") ==> Seq(
             "I am cow",
@@ -59,13 +59,13 @@ object ReadingWritingTests extends TestSuite {
             "And I look good on the barbecue"
           )
         }
-        test("stream"){
-          test - prep{ wd =>
+        test("stream") {
+          test - prep { wd =>
             os.read.lines.stream(wd / "File.txt").count() ==> 1
             os.read.lines.stream(wd / "Multi Line.txt").count() ==> 4
 
             // Streaming the lines to the console
-            for(line <- os.read.lines.stream(wd / "Multi Line.txt")){
+            for (line <- os.read.lines.stream(wd / "Multi Line.txt")) {
               println(line)
             }
           }
@@ -73,16 +73,16 @@ object ReadingWritingTests extends TestSuite {
       }
     }
 
-    test("write"){
-      test - prep{ wd =>
+    test("write") {
+      test - prep { wd =>
         os.write(wd / "New File.txt", "New File Contents")
         os.read(wd / "New File.txt") ==> "New File Contents"
 
         os.write(wd / "NewBinary.bin", Array[Byte](0, 1, 2, 3))
         os.read.bytes(wd / "NewBinary.bin") ==> Array[Byte](0, 1, 2, 3)
       }
-      test("append"){
-        test - prep{ wd =>
+      test("append") {
+        test - prep { wd =>
           os.read(wd / "File.txt") ==> "I am cow"
 
           os.write.append(wd / "File.txt", ", hear me moo")
@@ -97,8 +97,8 @@ object ReadingWritingTests extends TestSuite {
           os.read.bytes(wd / "misc" / "binary.png").length ==> 714
         }
       }
-      test("over"){
-        test - prep{ wd =>
+      test("over") {
+        test - prep { wd =>
           os.read(wd / "File.txt") ==> "I am cow"
           os.write.over(wd / "File.txt", "You are cow")
 
@@ -111,8 +111,8 @@ object ReadingWritingTests extends TestSuite {
           os.read(wd / "File.txt") ==> "We  are sow"
         }
       }
-      test("inputStream"){
-        test - prep{ wd =>
+      test("inputStream") {
+        test - prep { wd =>
           val out = os.write.outputStream(wd / "New File.txt")
           out.write('H')
           out.write('e')
@@ -125,8 +125,8 @@ object ReadingWritingTests extends TestSuite {
         }
       }
     }
-    test("truncate"){
-      test - prep{ wd =>
+    test("truncate") {
+      test - prep { wd =>
         os.read(wd / "File.txt") ==> "I am cow"
 
         os.truncate(wd / "File.txt", 4)
@@ -135,4 +135,3 @@ object ReadingWritingTests extends TestSuite {
     }
   }
 }
-

--- a/os/test/src-jvm/SubprocessTests.scala
+++ b/os/test/src-jvm/SubprocessTests.scala
@@ -8,13 +8,13 @@ import utest._
 
 import scala.collection.mutable
 
-object SubprocessTests extends TestSuite{
-  val scriptFolder = pwd/"os"/"test"/"resources"/"test"
+object SubprocessTests extends TestSuite {
+  val scriptFolder = pwd / "os" / "test" / "resources" / "test"
 
   val lsCmd = if (scala.util.Properties.isWin) "dir" else "ls"
 
   val tests = Tests {
-    test("lines"){
+    test("lines") {
       val res = TestUtil.proc(lsCmd, scriptFolder).call()
       assert(
         res.out.lines().exists(_.contains("File.txt")),
@@ -22,7 +22,7 @@ object SubprocessTests extends TestSuite{
         res.out.lines().exists(_.contains("folder2"))
       )
     }
-    test("string"){
+    test("string") {
       val res = TestUtil.proc(lsCmd, scriptFolder).call()
       assert(
         res.out.text().contains("File.txt"),
@@ -30,35 +30,35 @@ object SubprocessTests extends TestSuite{
         res.out.text().contains("folder2")
       )
     }
-    test("bytes"){
-      if(Unix()){
+    test("bytes") {
+      if (Unix()) {
         val res = proc(scriptFolder / "misc" / "echo", "abc").call()
         val listed = res.out.bytes
         listed ==> "abc\n".getBytes
       }
     }
-    test("chained"){
+    test("chained") {
       assert(
         proc("git", "init").call().out.text().contains("Reinitialized existing Git repository"),
         proc("git", "init").call().out.text().contains("Reinitialized existing Git repository"),
         TestUtil.proc(lsCmd, pwd).call().out.text().contains("Readme.adoc")
       )
     }
-    test("basicList"){
+    test("basicList") {
       val files = List("Readme.adoc", "build.sc")
       val output = TestUtil.proc(lsCmd, files).call().out.text()
       assert(files.forall(output.contains))
     }
-    test("listMixAndMatch"){
+    test("listMixAndMatch") {
       val stuff = List("I", "am", "bovine")
       val result = TestUtil.proc("echo", "Hello,", stuff, "hear me roar").call()
-      if(Unix())
+      if (Unix())
         assert(result.out.text().contains("Hello, " + stuff.mkString(" ") + " hear me roar"))
       else // win quotes multiword args
         assert(result.out.text().contains("Hello, " + stuff.mkString(" ") + " \"hear me roar\""))
     }
-    test("failures"){
-      val ex = intercept[os.SubprocessException]{
+    test("failures") {
+      val ex = intercept[os.SubprocessException] {
         TestUtil.proc(lsCmd, "does-not-exist").call(check = true, stderr = os.Pipe)
       }
       val res: CommandResult = ex.result
@@ -69,22 +69,21 @@ object SubprocessTests extends TestSuite{
       )
     }
 
-    test("filebased"){
-      if(Unix()){
-        assert(proc(scriptFolder/"misc"/"echo", "HELLO").call().out.lines().mkString == "HELLO")
+    test("filebased") {
+      if (Unix()) {
+        assert(proc(scriptFolder / "misc" / "echo", "HELLO").call().out.lines().mkString == "HELLO")
 
         val res: CommandResult =
-          proc(root/"bin"/"bash", "-c", "echo 'Hello'$ENV_ARG").call(
+          proc(root / "bin" / "bash", "-c", "echo 'Hello'$ENV_ARG").call(
             env = Map("ENV_ARG" -> "123")
           )
 
-        assert(res.out.text().trim()== "Hello123")
+        assert(res.out.text().trim() == "Hello123")
       }
     }
-    test("filebased2"){
-      if(Unix()){
-        val possiblePaths = Seq(root / "bin",
-                                root / "usr" / "bin").map { pfx => pfx / "echo" }
+    test("filebased2") {
+      if (Unix()) {
+        val possiblePaths = Seq(root / "bin", root / "usr" / "bin").map { pfx => pfx / "echo" }
         val res = proc("which", "echo").call()
         val echoRoot = Path(res.out.text().trim())
         assert(possiblePaths.contains(echoRoot))
@@ -93,7 +92,7 @@ object SubprocessTests extends TestSuite{
       }
     }
 
-    test("charSequence"){
+    test("charSequence") {
       val charSequence = new StringBuilder("This is a CharSequence")
       val cmd = Seq(
         "echo",
@@ -103,38 +102,45 @@ object SubprocessTests extends TestSuite{
       assert(res.out.text().trim() == charSequence.toString())
     }
 
-    test("envArgs"){ if(Unix()){
-      val res0 = proc("bash", "-c", "echo \"Hello$ENV_ARG\"").call(env = Map("ENV_ARG" -> "12"))
-      assert(res0.out.lines() == Seq("Hello12"))
+    test("envArgs") {
+      if (Unix()) {
+        val res0 = proc("bash", "-c", "echo \"Hello$ENV_ARG\"").call(env = Map("ENV_ARG" -> "12"))
+        assert(res0.out.lines() == Seq("Hello12"))
 
-      val res1 = proc("bash", "-c", "echo \"Hello$ENV_ARG\"").call(env = Map("ENV_ARG" -> "12"))
-      assert(res1.out.lines() == Seq("Hello12"))
+        val res1 = proc("bash", "-c", "echo \"Hello$ENV_ARG\"").call(env = Map("ENV_ARG" -> "12"))
+        assert(res1.out.lines() == Seq("Hello12"))
 
-      val res2 = proc("bash", "-c", "echo 'Hello$ENV_ARG'").call(env = Map("ENV_ARG" -> "12"))
-      assert(res2.out.lines() == Seq("Hello$ENV_ARG"))
+        val res2 = proc("bash", "-c", "echo 'Hello$ENV_ARG'").call(env = Map("ENV_ARG" -> "12"))
+        assert(res2.out.lines() == Seq("Hello$ENV_ARG"))
 
-      val res3 = proc("bash", "-c", "echo 'Hello'$ENV_ARG").call(env = Map("ENV_ARG" -> "123"))
-      assert(res3.out.lines() == Seq("Hello123"))
-    }}
-    test("multiChunk"){
+        val res3 = proc("bash", "-c", "echo 'Hello'$ENV_ARG").call(env = Map("ENV_ARG" -> "123"))
+        assert(res3.out.lines() == Seq("Hello123"))
+      }
+    }
+    test("multiChunk") {
       // Make sure that in the case where multiple chunks are being read from
       // the subprocess in quick succession, we ensure that the output handler
       // callbacks are properly ordered such that the output is aggregated
       // correctly
-      test("bashC"){ if(TestUtil.isInstalled("python")) {
-        os.proc("python", "-c",
-        """import sys, time
-          |for i in range(5):
-          |  for j in range(10):
-          |    sys.stdout.write(str(j))
-          |    # Make sure it comes as multiple chunks, but close together!
-          |    # Vary how close they are together to try and trigger race conditions
-          |    time.sleep(0.00001 * i)
-          |    sys.stdout.flush()
-        """.stripMargin).call().out.text() ==>
-          "01234567890123456789012345678901234567890123456789"
-      }}
-      test("jarTf"){
+      test("bashC") {
+        if (TestUtil.isInstalled("python")) {
+          os.proc(
+            "python",
+            "-c",
+            """import sys, time
+              |for i in range(5):
+              |  for j in range(10):
+              |    sys.stdout.write(str(j))
+              |    # Make sure it comes as multiple chunks, but close together!
+              |    # Vary how close they are together to try and trigger race conditions
+              |    time.sleep(0.00001 * i)
+              |    sys.stdout.flush()
+        """.stripMargin
+          ).call().out.text() ==>
+            "01234567890123456789012345678901234567890123456789"
+        }
+      }
+      test("jarTf") {
         // This was the original repro for the multi-chunk concurrency bugs
         val jarFile = os.pwd / "os" / "test" / "resources" / "misc" / "out.jar"
         assert(TestUtil.eqIgnoreNewlineStyle(
@@ -150,21 +156,21 @@ object SubprocessTests extends TestSuite{
         ))
       }
     }
-    test("workingDirectory"){
+    test("workingDirectory") {
       val listed1 = TestUtil.proc(lsCmd).call(cwd = pwd)
       val listed2 = TestUtil.proc(lsCmd).call(cwd = pwd / up)
 
       assert(listed2 != listed1)
     }
-    test("customWorkingDir"){
+    test("customWorkingDir") {
       val res1 = TestUtil.proc(lsCmd).call(cwd = pwd) // explicitly
       // or implicitly
       val res2 = TestUtil.proc(lsCmd).call()
     }
 
-    test("fileCustomWorkingDir"){
-      if(Unix()){
-        val output = proc(scriptFolder/"misc"/"echo_with_wd", "HELLO").call(cwd = root/"usr")
+    test("fileCustomWorkingDir") {
+      if (Unix()) {
+        val output = proc(scriptFolder / "misc" / "echo_with_wd", "HELLO").call(cwd = root / "usr")
         assert(output.out.lines() == Seq("HELLO /usr"))
       }
     }

--- a/os/test/src/OpTests.scala
+++ b/os/test/src/OpTests.scala
@@ -3,36 +3,35 @@ package test.os
 import java.nio.file.NoSuchFileException
 import java.nio.{file => nio}
 
-
 import utest._
 import os.{GlobSyntax, /}
-object OpTests extends TestSuite{
+object OpTests extends TestSuite {
 
   val tests = Tests {
-    val res = os.pwd/"os"/"test"/"resources"/"test"
+    val res = os.pwd / "os" / "test" / "resources" / "test"
     test("ls") - assert(
       os.list(res).toSet == Set(
-        res/"folder1",
-        res/"folder2",
-        res/"misc",
-        res/"os",
-        res/"File.txt",
-        res/"Multi Line.txt"
+        res / "folder1",
+        res / "folder2",
+        res / "misc",
+        res / "os",
+        res / "File.txt",
+        res / "Multi Line.txt"
       ),
-      os.list(res/"folder2").toSet == Set(
-        res/"folder2"/"nestedA",
-        res/"folder2"/"nestedB"
+      os.list(res / "folder2").toSet == Set(
+        res / "folder2" / "nestedA",
+        res / "folder2" / "nestedB"
       )
     )
-    test("rm"){
+    test("rm") {
       // shouldn't crash
-      os.remove.all(os.pwd/"out"/"scratch"/"nonexistent")
+      os.remove.all(os.pwd / "out" / "scratch" / "nonexistent")
       // shouldn't crash
-      os.remove(os.pwd/"out"/"scratch"/"nonexistent") ==> false
+      os.remove(os.pwd / "out" / "scratch" / "nonexistent") ==> false
 
       // should crash
-      intercept[NoSuchFileException]{
-        os.remove(os.pwd/"out"/"scratch"/"nonexistent", checkExists = true)
+      intercept[NoSuchFileException] {
+        os.remove(os.pwd / "out" / "scratch" / "nonexistent", checkExists = true)
       }
     }
   }

--- a/os/test/src/OsTestMain.scala
+++ b/os/test/src/OsTestMain.scala
@@ -1,7 +1,5 @@
 package test.os
 
 object OsTestMain {
-  def main(args: Array[String]): Unit = {
-
-  }
+  def main(args: Array[String]): Unit = {}
 }

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -5,20 +5,20 @@ import java.nio.file.Paths
 import os._
 import utest.{assert => _, _}
 import java.net.URI
-object PathTests extends TestSuite{
+object PathTests extends TestSuite {
   val tests = Tests {
-    test("Basic"){
-      val base = rel/"src"/"main"/"scala"
-      val subBase = sub/"src"/"main"/"scala"
-      test("Transformers"){
-        if(Unix()){
+    test("Basic") {
+      val base = rel / "src" / "main" / "scala"
+      val subBase = sub / "src" / "main" / "scala"
+      test("Transformers") {
+        if (Unix()) {
           // os.Path to java.nio.file.Path
-          assert((root/"omg").wrapped == Paths.get("/omg"))
+          assert((root / "omg").wrapped == Paths.get("/omg"))
 
           // java.nio.file.Path to os.Path
-          assert(root/"omg" == Path(Paths.get("/omg")))
-          assert(rel/"omg" == RelPath(Paths.get("omg")))
-          assert(sub/"omg" == SubPath(Paths.get("omg")))
+          assert(root / "omg" == Path(Paths.get("/omg")))
+          assert(rel / "omg" == RelPath(Paths.get("omg")))
+          assert(sub / "omg" == SubPath(Paths.get("omg")))
 
           // URI to os.Path
           assert(root / "omg" == Path(Paths.get("/omg").toUri()))
@@ -33,44 +33,43 @@ object PathTests extends TestSuite{
           intercept[IllegalArgumentException](Path(httpUri))
           intercept[IllegalArgumentException](Path(ldapUri))
 
-
           // os.Path to String
-          assert((root/"omg").toString == "/omg")
-          assert((rel/"omg").toString == "omg")
-          assert((sub/"omg").toString == "omg")
-          assert((up/"omg").toString == "../omg")
-          assert((up/up/"omg").toString == "../../omg")
+          assert((root / "omg").toString == "/omg")
+          assert((rel / "omg").toString == "omg")
+          assert((sub / "omg").toString == "omg")
+          assert((up / "omg").toString == "../omg")
+          assert((up / up / "omg").toString == "../../omg")
 
           // String to os.Path
-          assert(root/"omg" == Path("/omg"))
-          assert(rel/"omg" == RelPath("omg"))
-          assert(sub/"omg" == SubPath("omg"))
+          assert(root / "omg" == Path("/omg"))
+          assert(rel / "omg" == RelPath("omg"))
+          assert(sub / "omg" == SubPath("omg"))
         }
       }
 
-      test("BasePath"){
-        test("baseName"){
+      test("BasePath") {
+        test("baseName") {
           assert((base / "baseName.ext").baseName == "baseName")
           assert((base / "baseName.v2.0.ext").baseName == "baseName.v2.0")
           assert((base / "baseOnly").baseName == "baseOnly")
           assert((base / "baseOnly.").baseName == "baseOnly")
         }
 
-        test("ext"){
+        test("ext") {
           assert((base / "baseName.ext").ext == "ext")
           assert((base / "baseName.v2.0.ext").ext == "ext")
           assert((base / "baseOnly").ext == "")
           assert((base / "baseOnly.").ext == "")
         }
 
-        test("emptyExt"){
+        test("emptyExt") {
           os.root.ext ==> ""
           os.rel.ext ==> ""
           os.sub.ext ==> ""
           os.up.ext ==> ""
         }
 
-        test("emptyLast"){
+        test("emptyLast") {
           intercept[PathError.LastOnEmptyPath](os.root.last).getMessage ==>
             "empty path has no last segment"
           intercept[PathError.LastOnEmptyPath](os.rel.last).getMessage ==>
@@ -82,10 +81,10 @@ object PathTests extends TestSuite{
         }
       }
 
-      test("RelPath"){
-        test("Constructors"){
-          test("Symbol"){
-            if (Unix()){
+      test("RelPath") {
+        test("Constructors") {
+          test("Symbol") {
+            if (Unix()) {
               val rel1 = base / "ammonite"
               assert(
                 rel1.segments == Seq("src", "main", "scala", "ammonite"),
@@ -93,8 +92,8 @@ object PathTests extends TestSuite{
               )
             }
           }
-          test("String"){
-            if (Unix()){
+          test("String") {
+            if (Unix()) {
               val rel1 = base / "Path.scala"
               assert(
                 rel1.segments == Seq("src", "main", "scala", "Path.scala"),
@@ -102,31 +101,31 @@ object PathTests extends TestSuite{
               )
             }
           }
-          test("Combos"){
+          test("Combos") {
             def check(rel1: RelPath) = assert(
               rel1.segments == Seq("src", "main", "scala", "sub1", "sub2"),
               rel1.toString == "src/main/scala/sub1/sub2"
             )
-            test("ArrayString"){
-              if (Unix()){
+            test("ArrayString") {
+              if (Unix()) {
                 val arr = Array("sub1", "sub2")
                 check(base / arr)
               }
             }
-            test("ArraySymbol"){
-              if (Unix()){
+            test("ArraySymbol") {
+              if (Unix()) {
                 val arr = Array("sub1", "sub2")
                 check(base / arr)
               }
             }
-            test("SeqString"){
+            test("SeqString") {
               if (Unix()) check(base / Seq("sub1", "sub2"))
             }
-            test("SeqSymbol"){
+            test("SeqSymbol") {
               if (Unix()) check(base / Seq("sub1", "sub2"))
             }
-            test("SeqSeqSeqSymbol"){
-              if (Unix()){
+            test("SeqSeqSeqSymbol") {
+              if (Unix()) {
                 check(
                   base / Seq(Seq(Seq("sub1"), Seq()), Seq(Seq("sub2")), Seq())
                 )
@@ -134,20 +133,22 @@ object PathTests extends TestSuite{
             }
           }
         }
-        test("Relativize"){
+        test("Relativize") {
           def eq[T](p: T, q: T) = assert(p == q)
-          test - eq(rel/"omg"/"bbq"/"wtf" relativeTo rel/"omg"/"bbq"/"wtf", rel)
-          test - eq(rel/"omg"/"bbq" relativeTo rel/"omg"/"bbq"/"wtf", up)
-          test - eq(rel/"omg"/"bbq"/"wtf" relativeTo rel/"omg"/"bbq", rel/"wtf")
-          test - eq(rel/"omg"/"bbq" relativeTo rel/"omg"/"bbq"/"wtf", up)
-          test - eq(up/"omg"/"bbq" relativeTo rel/"omg"/"bbq", up/up/up/"omg"/"bbq")
-          test - intercept[PathError.NoRelativePath](rel/"omg"/"bbq" relativeTo up/"omg"/"bbq")
+          test - eq(rel / "omg" / "bbq" / "wtf" relativeTo rel / "omg" / "bbq" / "wtf", rel)
+          test - eq(rel / "omg" / "bbq" relativeTo rel / "omg" / "bbq" / "wtf", up)
+          test - eq(rel / "omg" / "bbq" / "wtf" relativeTo rel / "omg" / "bbq", rel / "wtf")
+          test - eq(rel / "omg" / "bbq" relativeTo rel / "omg" / "bbq" / "wtf", up)
+          test - eq(up / "omg" / "bbq" relativeTo rel / "omg" / "bbq", up / up / up / "omg" / "bbq")
+          test - intercept[PathError.NoRelativePath](
+            rel / "omg" / "bbq" relativeTo up / "omg" / "bbq"
+          )
         }
       }
-      test("SubPath"){
-        test("Constructors"){
-          test("Symbol"){
-            if (Unix()){
+      test("SubPath") {
+        test("Constructors") {
+          test("Symbol") {
+            if (Unix()) {
               val rel1 = subBase / "ammonite"
               assert(
                 rel1.segments == Seq("src", "main", "scala", "ammonite"),
@@ -155,8 +156,8 @@ object PathTests extends TestSuite{
               )
             }
           }
-          test("String"){
-            if (Unix()){
+          test("String") {
+            if (Unix()) {
               val rel1 = subBase / "Path.scala"
               assert(
                 rel1.segments == Seq("src", "main", "scala", "Path.scala"),
@@ -164,31 +165,31 @@ object PathTests extends TestSuite{
               )
             }
           }
-          test("Combos"){
+          test("Combos") {
             def check(rel1: SubPath) = assert(
               rel1.segments == Seq("src", "main", "scala", "sub1", "sub2"),
               rel1.toString == "src/main/scala/sub1/sub2"
             )
-            test("ArrayString"){
-              if (Unix()){
+            test("ArrayString") {
+              if (Unix()) {
                 val arr = Array("sub1", "sub2")
                 check(subBase / arr)
               }
             }
-            test("ArraySymbol"){
-              if (Unix()){
+            test("ArraySymbol") {
+              if (Unix()) {
                 val arr = Array("sub1", "sub2")
                 check(subBase / arr)
               }
             }
-            test("SeqString"){
+            test("SeqString") {
               if (Unix()) check(subBase / Seq("sub1", "sub2"))
             }
-            test("SeqSymbol"){
+            test("SeqSymbol") {
               if (Unix()) check(subBase / Seq("sub1", "sub2"))
             }
-            test("SeqSeqSeqSymbol"){
-              if (Unix()){
+            test("SeqSeqSeqSymbol") {
+              if (Unix()) {
                 check(
                   subBase / Seq(Seq(Seq("sub1"), Seq()), Seq(Seq("sub2")), Seq())
                 )
@@ -196,81 +197,83 @@ object PathTests extends TestSuite{
             }
           }
         }
-        test("Relativize"){
+        test("Relativize") {
           def eq[T](p: T, q: T) = assert(p == q)
-          test - eq(sub/"omg"/"bbq"/"wtf" relativeTo sub/"omg"/"bbq"/"wtf", rel)
-          test - eq(sub/"omg"/"bbq" relativeTo sub/"omg"/"bbq"/"wtf", up)
-          test - eq(sub/"omg"/"bbq"/"wtf" relativeTo sub/"omg"/"bbq", rel/"wtf")
-          test - eq(sub/"omg"/"bbq" relativeTo sub/"omg"/"bbq"/"wtf", up)
+          test - eq(sub / "omg" / "bbq" / "wtf" relativeTo sub / "omg" / "bbq" / "wtf", rel)
+          test - eq(sub / "omg" / "bbq" relativeTo sub / "omg" / "bbq" / "wtf", up)
+          test - eq(sub / "omg" / "bbq" / "wtf" relativeTo sub / "omg" / "bbq", rel / "wtf")
+          test - eq(sub / "omg" / "bbq" relativeTo sub / "omg" / "bbq" / "wtf", up)
         }
       }
 
-      test("AbsPath"){
+      test("AbsPath") {
         val d = pwd
         val abs = d / base
-        test("Constructor"){
+        test("Constructor") {
           if (Unix()) assert(
             abs.toString.drop(d.toString.length) == "/src/main/scala",
             abs.toString.length > d.toString.length
           )
         }
-        test("Relativize"){
+        test("Relativize") {
           def eq[T](p: T, q: T) = assert(p == q)
-          test - eq(root/"omg"/"bbq"/"wtf" relativeTo root/"omg"/"bbq"/"wtf", rel)
-          test - eq(root/"omg"/"bbq" relativeTo root/"omg"/"bbq"/"wtf", up)
-          test - eq(root/"omg"/"bbq"/"wtf" relativeTo root/"omg"/"bbq", rel/"wtf")
-          test - eq(root/"omg"/"bbq" relativeTo root/"omg"/"bbq"/"wtf", up)
-          test - intercept[PathError.NoRelativePath](rel/"omg"/"bbq" relativeTo up/"omg"/"bbq")
+          test - eq(root / "omg" / "bbq" / "wtf" relativeTo root / "omg" / "bbq" / "wtf", rel)
+          test - eq(root / "omg" / "bbq" relativeTo root / "omg" / "bbq" / "wtf", up)
+          test - eq(root / "omg" / "bbq" / "wtf" relativeTo root / "omg" / "bbq", rel / "wtf")
+          test - eq(root / "omg" / "bbq" relativeTo root / "omg" / "bbq" / "wtf", up)
+          test - intercept[PathError.NoRelativePath](
+            rel / "omg" / "bbq" relativeTo up / "omg" / "bbq"
+          )
         }
       }
-      test("Ups"){
-        test("RelativeUps"){
-          val rel2 = base/up
-          assert(rel2 == rel/"src"/"main")
-          assert(base/up/up == rel/"src")
-          assert(base/up/up/up == rel)
-          assert(base/up/up/up/up == up)
-          assert(base/up/up/up/up/up == up/up)
-          assert(up/base == up/"src"/"main"/"scala")
+      test("Ups") {
+        test("RelativeUps") {
+          val rel2 = base / up
+          assert(rel2 == rel / "src" / "main")
+          assert(base / up / up == rel / "src")
+          assert(base / up / up / up == rel)
+          assert(base / up / up / up / up == up)
+          assert(base / up / up / up / up / up == up / up)
+          assert(up / base == up / "src" / "main" / "scala")
         }
-        test("AbsoluteUps"){
+        test("AbsoluteUps") {
           // Keep applying `up` and verify that the path gets
           // shorter and shorter and eventually errors.
           var abs = pwd
           var i = abs.segmentCount
-          while(i > 0){
+          while (i > 0) {
             abs /= up
-            i-=1
+            i -= 1
             assert(abs.segmentCount == i)
           }
-          intercept[PathError.AbsolutePathOutsideRoot.type]{ abs/up }
+          intercept[PathError.AbsolutePathOutsideRoot.type] { abs / up }
         }
-        test("RootUpBreak"){
-          intercept[PathError.AbsolutePathOutsideRoot.type]{ root/up }
-          val x = root/"omg"
-          val y = x/up
-          intercept[PathError.AbsolutePathOutsideRoot.type]{ y / up }
+        test("RootUpBreak") {
+          intercept[PathError.AbsolutePathOutsideRoot.type] { root / up }
+          val x = root / "omg"
+          val y = x / up
+          intercept[PathError.AbsolutePathOutsideRoot.type] { y / up }
         }
       }
-      test("Comparison"){
+      test("Comparison") {
         test("Relative") - {
-          assert(rel/"omg"/"wtf" == rel/"omg"/"wtf")
-          assert(rel/"omg"/"wtf" != rel/"omg"/"wtf"/"bbq")
-          assert(rel/"omg"/"wtf"/"bbq" startsWith rel/"omg"/"wtf")
-          assert(rel/"omg"/"wtf" startsWith rel/"omg"/"wtf")
-          assert(up/"omg"/"wtf" startsWith up/"omg"/"wtf")
-          assert(!(rel/"omg"/"wtf" startsWith rel/"omg"/"wtf"/"bbq"))
-          assert(!(up/"omg"/"wtf" startsWith rel/"omg"/"wtf"))
-          assert(!(rel/"omg"/"wtf" startsWith up/"omg"/"wtf"))
+          assert(rel / "omg" / "wtf" == rel / "omg" / "wtf")
+          assert(rel / "omg" / "wtf" != rel / "omg" / "wtf" / "bbq")
+          assert(rel / "omg" / "wtf" / "bbq" startsWith rel / "omg" / "wtf")
+          assert(rel / "omg" / "wtf" startsWith rel / "omg" / "wtf")
+          assert(up / "omg" / "wtf" startsWith up / "omg" / "wtf")
+          assert(!(rel / "omg" / "wtf" startsWith rel / "omg" / "wtf" / "bbq"))
+          assert(!(up / "omg" / "wtf" startsWith rel / "omg" / "wtf"))
+          assert(!(rel / "omg" / "wtf" startsWith up / "omg" / "wtf"))
         }
         test("Absolute") - {
-          assert(root/"omg"/"wtf" == root/"omg"/"wtf")
-          assert(root/"omg"/"wtf" != root/"omg"/"wtf"/"bbq")
-          assert(root/"omg"/"wtf"/"bbq" startsWith root/"omg"/"wtf")
-          assert(root/"omg"/"wtf" startsWith root/"omg"/"wtf")
-          assert(!(root/"omg"/"wtf" startsWith root/"omg"/"wtf"/"bbq"))
+          assert(root / "omg" / "wtf" == root / "omg" / "wtf")
+          assert(root / "omg" / "wtf" != root / "omg" / "wtf" / "bbq")
+          assert(root / "omg" / "wtf" / "bbq" startsWith root / "omg" / "wtf")
+          assert(root / "omg" / "wtf" startsWith root / "omg" / "wtf")
+          assert(!(root / "omg" / "wtf" startsWith root / "omg" / "wtf" / "bbq"))
         }
-        test("Invalid"){
+        test("Invalid") {
           compileError("""root/"omg"/"wtf" < "omg"/"wtf"""")
           compileError("""root/"omg"/"wtf" > "omg"/"wtf"""")
           compileError(""""omg"/"wtf" < root/"omg"/"wtf"""")
@@ -278,97 +281,99 @@ object PathTests extends TestSuite{
         }
       }
     }
-    test("Errors"){
-      test("InvalidChars"){
-        val ex = intercept[PathError.InvalidSegment](rel/"src"/"Main/.scala")
+    test("Errors") {
+      test("InvalidChars") {
+        val ex = intercept[PathError.InvalidSegment](rel / "src" / "Main/.scala")
 
         val PathError.InvalidSegment("Main/.scala", msg1) = ex
 
         assert(msg1.contains("[/] is not a valid character to appear in a path segment"))
 
-        val ex2 = intercept[PathError.InvalidSegment](root/"hello"/".."/"world")
+        val ex2 = intercept[PathError.InvalidSegment](root / "hello" / ".." / "world")
 
         val PathError.InvalidSegment("..", msg2) = ex2
 
         assert(msg2.contains("use the `up` segment from `os.up`"))
       }
-      test("InvalidSegments"){
-        intercept[PathError.InvalidSegment]{root/ "core/src/test"}
-        intercept[PathError.InvalidSegment]{root/ ""}
-        intercept[PathError.InvalidSegment]{root/ "."}
-        intercept[PathError.InvalidSegment]{root/ ".."}
+      test("InvalidSegments") {
+        intercept[PathError.InvalidSegment] { root / "core/src/test" }
+        intercept[PathError.InvalidSegment] { root / "" }
+        intercept[PathError.InvalidSegment] { root / "." }
+        intercept[PathError.InvalidSegment] { root / ".." }
       }
-      test("EmptySegment"){
-        intercept[PathError.InvalidSegment](rel/"src" / "")
-        intercept[PathError.InvalidSegment](rel/"src" / ".")
-        intercept[PathError.InvalidSegment](rel/"src" / "..")
+      test("EmptySegment") {
+        intercept[PathError.InvalidSegment](rel / "src" / "")
+        intercept[PathError.InvalidSegment](rel / "src" / ".")
+        intercept[PathError.InvalidSegment](rel / "src" / "..")
       }
-      test("CannotRelativizeAbsAndRel"){if(Unix()){
-        val abs = pwd
-        val rel = os.rel/"omg"/"wtf"
-        compileError("""
+      test("CannotRelativizeAbsAndRel") {
+        if (Unix()) {
+          val abs = pwd
+          val rel = os.rel / "omg" / "wtf"
+          compileError("""
           abs.relativeTo(rel)
         """).msg.toLowerCase.contains("required: os.path") ==> true
-        compileError("""
+          compileError("""
           rel.relativeTo(abs)
         """).msg.toLowerCase.contains("required: os.relpath") ==> true
-      }}
-      test("InvalidCasts"){
-        if(Unix()){
+        }
+      }
+      test("InvalidCasts") {
+        if (Unix()) {
           intercept[IllegalArgumentException](Path("omg/cow"))
           intercept[IllegalArgumentException](RelPath("/omg/cow"))
         }
       }
-      test("Pollution"){
+      test("Pollution") {
         // Make sure we"re" not polluting too much
         compileError(""""omg".ext""")
         compileError(""" "omg".ext """)
       }
     }
-    test("Extractors"){
-      test("paths"){
-        val a/b/c/d/"omg" = pwd/"A"/"B"/"C"/"D"/"omg"
-        assert(a == pwd/"A")
+    test("Extractors") {
+      test("paths") {
+        val a / b / c / d / "omg" = pwd / "A" / "B" / "C" / "D" / "omg"
+        assert(a == pwd / "A")
         assert(b == "B")
         assert(c == "C")
         assert(d == "D")
 
         // If the paths aren"t" deep enough, it
         // just doesn"t" match but doesn"t" blow up
-        root/"omg" match {
-          case a3/b3/c3/d3/e3 => assert(false)
+        root / "omg" match {
+          case a3 / b3 / c3 / d3 / e3 => assert(false)
           case _ =>
         }
       }
     }
-    test("sorting"){
+    test("sorting") {
       test - {
         assert(
-          Seq(root/"c", root, root/"b", root/"a").sorted ==
-          Seq(root, root/"a", root/"b", root/"c")
+          Seq(root / "c", root, root / "b", root / "a").sorted ==
+            Seq(root, root / "a", root / "b", root / "c")
         )
       }
 
       test - assert(
-        Seq(up/"c", up/up/"c", rel/"b"/"c", rel/"a"/"c", rel/"a"/"d").sorted ==
-        Seq(rel/"a"/"c", rel/"a"/"d", rel/"b"/"c", up/"c", up/up/"c")
+        Seq(up / "c", up / up / "c", rel / "b" / "c", rel / "a" / "c", rel / "a" / "d").sorted ==
+          Seq(rel / "a" / "c", rel / "a" / "d", rel / "b" / "c", up / "c", up / up / "c")
       )
 
       test - assert(
         Seq(os.root / "yo", os.root / "yo").sorted ==
-        Seq(os.root / "yo", os.root / "yo")
+          Seq(os.root / "yo", os.root / "yo")
       )
     }
-    test("construction"){
-      test("success"){
-        if(Unix()){
+    test("construction") {
+      test("success") {
+        if (Unix()) {
           val relStr = "hello/cow/world/.."
           val absStr = "/hello/world"
 
           val lhs = Path(absStr)
-          val rhs = root/"hello"/"world"
+          val rhs = root / "hello" / "world"
           assert(
-            RelPath(relStr) == rel/"hello"/"cow",
+            RelPath(relStr) == rel / "hello" / "cow",
             // Path(...) also allows paths starting with ~,
             // which is expanded to become your home directory
             lhs == rhs
@@ -379,55 +384,54 @@ object PathTests extends TestSuite{
           val relIoFile = new java.io.File(relStr)
           val absNioFile = java.nio.file.Paths.get(absStr)
 
-
-          assert(RelPath(relIoFile) == rel/"hello"/"cow")
-          assert(Path(absNioFile) == root/"hello"/"world")
-          assert(Path(relIoFile, root/"base") == root/"base"/"hello"/"cow")
+          assert(RelPath(relIoFile) == rel / "hello" / "cow")
+          assert(Path(absNioFile) == root / "hello" / "world")
+          assert(Path(relIoFile, root / "base") == root / "base" / "hello" / "cow")
         }
       }
-      test("basepath"){
-        if(Unix()){
+      test("basepath") {
+        if (Unix()) {
           val relStr = "hello/cow/world/.."
           val absStr = "/hello/world"
           assert(
-            FilePath(relStr) == rel/"hello"/"cow",
-            FilePath(absStr) == root/"hello"/"world"
+            FilePath(relStr) == rel / "hello" / "cow",
+            FilePath(absStr) == root / "hello" / "world"
           )
         }
       }
-      test("based"){
-        if(Unix()){
+      test("based") {
+        if (Unix()) {
           val relStr = "hello/cow/world/.."
           val absStr = "/hello/world"
           val basePath: FilePath = FilePath(relStr)
-          assert(Path(relStr, root/"base") == root/"base"/"hello"/"cow")
-          assert(Path(absStr, root/"base") == root/"hello"/"world")
-          assert(Path(basePath, root/"base") == root/"base"/"hello"/"cow")
+          assert(Path(relStr, root / "base") == root / "base" / "hello" / "cow")
+          assert(Path(absStr, root / "base") == root / "hello" / "world")
+          assert(Path(basePath, root / "base") == root / "base" / "hello" / "cow")
           assert(Path(".", pwd).last != "")
         }
       }
-      test("failure"){
-        if(Unix()){
+      test("failure") {
+        if (Unix()) {
           val relStr = "hello/.."
-          intercept[java.lang.IllegalArgumentException]{
+          intercept[java.lang.IllegalArgumentException] {
             Path(relStr)
           }
 
           val absStr = "/hello"
-          intercept[java.lang.IllegalArgumentException]{
+          intercept[java.lang.IllegalArgumentException] {
             RelPath(absStr)
           }
 
           val tooManyUpsStr = "/hello/../.."
-          intercept[PathError.AbsolutePathOutsideRoot.type]{
+          intercept[PathError.AbsolutePathOutsideRoot.type] {
             Path(tooManyUpsStr)
           }
         }
       }
     }
-    test("issue159"){
-      val result1 = os.rel / Seq(os.up, os.rel/"hello", os.rel/"world")
-      val result2 = os.rel / Array(os.up, os.rel/"hello", os.rel/"world")
+    test("issue159") {
+      val result1 = os.rel / Seq(os.up, os.rel / "hello", os.rel / "world")
+      val result2 = os.rel / Array(os.up, os.rel / "hello", os.rel / "world")
       val expected = os.up / "hello" / "world"
       assert(result1 == expected)
       assert(result2 == expected)

--- a/os/test/src/unix.scala
+++ b/os/test/src/unix.scala
@@ -1,13 +1,13 @@
 package test.os
 
 /**
-  * Created by haoyi on 2/17/16.
-  */
+ * Created by haoyi on 2/17/16.
+ */
 object Unix {
   def apply(): Boolean = java.nio.file.Paths.get("").toAbsolutePath.getRoot.toString == "/"
 }
 
 /**
-  * Dummy class just used to test classloader relative/absolute resource logic
-  */
+ * Dummy class just used to test classloader relative/absolute resource logic
+ */
 class Testing

--- a/os/watch/test/src/WatchTests.scala
+++ b/os/watch/test/src/WatchTests.scala
@@ -4,135 +4,136 @@ import utest._
 
 object WatchTests extends TestSuite with TestSuite.Retries {
   override val utestRetryCount =
-    if(sys.env.get("CI").contains("true")) {
-      if(sys.env.get("RUNNER_OS").contains("macOS")) 10
+    if (sys.env.get("CI").contains("true")) {
+      if (sys.env.get("RUNNER_OS").contains("macOS")) 10
       else 3
     } else {
       0
     }
 
   val tests = Tests {
-    test("singleFolder") - _root_.test.os.TestUtil.prep{wd => if (_root_.test.os.Unix()){
-      val changedPaths = collection.mutable.Set.empty[os.Path]
-      _root_.os.watch.watch(
-        Seq(wd),
-        onEvent = _.foreach(changedPaths.add)
-      )
+    test("singleFolder") - _root_.test.os.TestUtil.prep { wd =>
+      if (_root_.test.os.Unix()) {
+        val changedPaths = collection.mutable.Set.empty[os.Path]
+        _root_.os.watch.watch(
+          Seq(wd),
+          onEvent = _.foreach(changedPaths.add)
+        )
 
 //      os.write(wd / "lols", "")
 //      Thread.sleep(100)
 
-      changedPaths.clear()
-
-      def checkFileManglingChanges(p: os.Path) = {
-
-        checkChanges(
-          os.write(p, ""),
-          Set(p.subRelativeTo(wd))
-        )
-
-        checkChanges(
-          os.write.append(p, "hello"),
-          Set(p.subRelativeTo(wd))
-        )
-
-        checkChanges(
-          os.write.over(p, "world"),
-          Set(p.subRelativeTo(wd))
-        )
-
-        checkChanges(
-          os.truncate(p, 1),
-          Set(p.subRelativeTo(wd))
-        )
-
-        checkChanges(
-          os.remove(p),
-          Set(p.subRelativeTo(wd))
-        )
-      }
-      def checkChanges(action: => Unit, expectedChangedPaths: Set[os.SubPath]) = synchronized {
         changedPaths.clear()
-        action
-        Thread.sleep(200)
-        val changedSubPaths = changedPaths.map(_.subRelativeTo(wd))
-        assert(expectedChangedPaths == changedSubPaths)
-      }
 
-      checkFileManglingChanges(wd / "test")
+        def checkFileManglingChanges(p: os.Path) = {
 
-      checkChanges(
-        os.remove(wd / "File.txt"),
-        Set(os.sub / "File.txt")
-      )
+          checkChanges(
+            os.write(p, ""),
+            Set(p.subRelativeTo(wd))
+          )
 
-      checkChanges(
-        os.makeDir(wd / "my-new-folder"),
-        Set(os.sub / "my-new-folder")
-      )
+          checkChanges(
+            os.write.append(p, "hello"),
+            Set(p.subRelativeTo(wd))
+          )
 
-      checkFileManglingChanges(wd / "my-new-folder" / "test")
+          checkChanges(
+            os.write.over(p, "world"),
+            Set(p.subRelativeTo(wd))
+          )
 
-      checkChanges(
-        os.move(wd / "folder2", wd / "folder3"),
-        Set(
-          os.sub / "folder2",
-          os.sub / "folder3",
+          checkChanges(
+            os.truncate(p, 1),
+            Set(p.subRelativeTo(wd))
+          )
 
-          os.sub / "folder3" / "nestedA",
-          os.sub / "folder3" / "nestedA" / "a.txt",
-          os.sub / "folder3" / "nestedB",
-          os.sub / "folder3" / "nestedB" / "b.txt"
-        )
-      )
-
-      checkChanges(
-        os.copy(wd / "folder3", wd / "folder4"),
-        Set(
-          os.sub / "folder4",
-          os.sub / "folder4" / "nestedA",
-          os.sub / "folder4" / "nestedA" / "a.txt",
-          os.sub / "folder4" / "nestedB",
-          os.sub / "folder4" / "nestedB" / "b.txt"
-        )
-      )
-
-      checkChanges(
-        os.remove.all(wd / "folder4"),
-        Set(
-          os.sub / "folder4",
-          os.sub / "folder4" / "nestedA",
-          os.sub / "folder4" / "nestedA" / "a.txt",
-          os.sub / "folder4" / "nestedB",
-          os.sub / "folder4" / "nestedB" / "b.txt"
-        )
-      )
-
-      checkFileManglingChanges(wd / "folder3" / "nestedA" / "double-nested-file")
-      checkFileManglingChanges(wd / "folder3" / "nestedB" / "double-nested-file")
-
-      checkChanges(
-        os.symlink(wd / "newlink", wd / "doesntexist"),
-        Set(os.sub / "newlink")
-      )
-
-      checkChanges(
-        os.symlink(wd / "newlink2", wd / "folder3"),
-        Set(os.sub / "newlink2")
-      )
-
-      checkChanges(
-        os.hardlink(wd / "newlink3", wd / "folder3" / "nestedA" / "a.txt"),
-        System.getProperty("os.name") match{
-          case "Linux" => Set(os.sub / "newlink3")
-          case "Mac OS X" =>
-            Set(
-              os.sub / "newlink3",
-              os.sub / "folder3" / "nestedA",
-              os.sub / "folder3" / "nestedA" / "a.txt"
-            )
+          checkChanges(
+            os.remove(p),
+            Set(p.subRelativeTo(wd))
+          )
         }
-      )
-    }}
+        def checkChanges(action: => Unit, expectedChangedPaths: Set[os.SubPath]) = synchronized {
+          changedPaths.clear()
+          action
+          Thread.sleep(200)
+          val changedSubPaths = changedPaths.map(_.subRelativeTo(wd))
+          assert(expectedChangedPaths == changedSubPaths)
+        }
+
+        checkFileManglingChanges(wd / "test")
+
+        checkChanges(
+          os.remove(wd / "File.txt"),
+          Set(os.sub / "File.txt")
+        )
+
+        checkChanges(
+          os.makeDir(wd / "my-new-folder"),
+          Set(os.sub / "my-new-folder")
+        )
+
+        checkFileManglingChanges(wd / "my-new-folder" / "test")
+
+        checkChanges(
+          os.move(wd / "folder2", wd / "folder3"),
+          Set(
+            os.sub / "folder2",
+            os.sub / "folder3",
+            os.sub / "folder3" / "nestedA",
+            os.sub / "folder3" / "nestedA" / "a.txt",
+            os.sub / "folder3" / "nestedB",
+            os.sub / "folder3" / "nestedB" / "b.txt"
+          )
+        )
+
+        checkChanges(
+          os.copy(wd / "folder3", wd / "folder4"),
+          Set(
+            os.sub / "folder4",
+            os.sub / "folder4" / "nestedA",
+            os.sub / "folder4" / "nestedA" / "a.txt",
+            os.sub / "folder4" / "nestedB",
+            os.sub / "folder4" / "nestedB" / "b.txt"
+          )
+        )
+
+        checkChanges(
+          os.remove.all(wd / "folder4"),
+          Set(
+            os.sub / "folder4",
+            os.sub / "folder4" / "nestedA",
+            os.sub / "folder4" / "nestedA" / "a.txt",
+            os.sub / "folder4" / "nestedB",
+            os.sub / "folder4" / "nestedB" / "b.txt"
+          )
+        )
+
+        checkFileManglingChanges(wd / "folder3" / "nestedA" / "double-nested-file")
+        checkFileManglingChanges(wd / "folder3" / "nestedB" / "double-nested-file")
+
+        checkChanges(
+          os.symlink(wd / "newlink", wd / "doesntexist"),
+          Set(os.sub / "newlink")
+        )
+
+        checkChanges(
+          os.symlink(wd / "newlink2", wd / "folder3"),
+          Set(os.sub / "newlink2")
+        )
+
+        checkChanges(
+          os.hardlink(wd / "newlink3", wd / "folder3" / "nestedA" / "a.txt"),
+          System.getProperty("os.name") match {
+            case "Linux" => Set(os.sub / "newlink3")
+            case "Mac OS X" =>
+              Set(
+                os.sub / "newlink3",
+                os.sub / "folder3" / "nestedA",
+                os.sub / "folder3" / "nestedA" / "a.txt"
+              )
+          }
+        )
+      }
+    }
   }
 }


### PR DESCRIPTION
- Update Scalafmt to 3.7.3
- Reformatted test code
- Update .git-blame-ignore-revs
- Update CI check format setup
- No need to inherit ScalamfmtModule
