### PR TITLE
Add javadoc.io link and badge to Readme

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -14,7 +14,7 @@
 image:{link-oslib}/actions/workflows/build.yml/badge.svg[Build Status,link={link-oslib}/actions]
 image:https://badges.gitter.im/Join%20Chat.svg[Gitter Chat,link={link-oslib-gitter}]
 image:https://img.shields.io/badge/patreon-sponsor-ff69b4.svg[Patreon,link=https://www.patreon.com/lihaoyi]
-image:https://javadoc.io/badge2/com.lihaoyi/os-lib_3/javadoc.svg[API Docs,link=https://javadoc.io/doc/com.lihaoyi/os-lib_3]
+image:https://javadoc.io/badge2/com.lihaoyi/os-lib_3/javadoc.svg[API Docs (Scala 3),link=https://javadoc.io/doc/com.lihaoyi/os-lib_3]
 
 [source,scala]
 ----
@@ -87,7 +87,7 @@ ivy"com.lihaoyi::os-lib:{version}"
 "com.lihaoyi" %% "os-lib" % "{version}"
 ----
 
-https://javadoc.io/doc/com.lihaoyi/os-lib_3[API Documentation]
+https://javadoc.io/doc/com.lihaoyi/os-lib_3[API Documentation (Scala 3)]
 
 == Cookbook
 

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -14,6 +14,7 @@
 image:{link-oslib}/actions/workflows/build.yml/badge.svg[Build Status,link={link-oslib}/actions]
 image:https://badges.gitter.im/Join%20Chat.svg[Gitter Chat,link={link-oslib-gitter}]
 image:https://img.shields.io/badge/patreon-sponsor-ff69b4.svg[Patreon,link=https://www.patreon.com/lihaoyi]
+image:https://javadoc.io/badge2/com.lihaoyi/os-lib_3/javadoc.svg[API Docs,link=https://javadoc.io/doc/com.lihaoyi/os-lib_3]
 
 [source,scala]
 ----
@@ -85,6 +86,8 @@ ivy"com.lihaoyi::os-lib:{version}"
 // SBT
 "com.lihaoyi" %% "os-lib" % "{version}"
 ----
+
+https://javadoc.io/doc/com.lihaoyi/os-lib_3[API Documentation]
 
 == Cookbook
 


### PR DESCRIPTION
Regarding #179. While OS-Lib is small and the Readme has the cookbook already, it'd also be helpful to have some API documentation to search through. This PR adds a link to https://javadoc.io/doc/com.lihaoyi/os-lib_3 as well as a badge at the top of the Readme. I only put in a link to the docs for the `os-lib_3` artifact since I figured it'd be the same for Scala 3 as well as Scala 2.13, but if not, I guess two links, one for Scala 3 and one for Scala 2, can be put in.