### PR TITLE
fix for issue-201

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,13 @@ target/
 .project
 .cache
 .sbtserver
+.scala-build/
+.bsp/
 project/.sbtserver
 tags
 nohup.out
 out
 lowered.hnir
+
+# ignore vim swap files
+*.sw[op]

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,3 @@ tags
 nohup.out
 out
 lowered.hnir
-
-# ignore vim swap files
-*.sw[op]

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -407,8 +407,6 @@ object Path {
       } else {
         implicitly[PathConvertible[T]].apply(f0)
       }
-      // in Windows, getNameCount includes the drive letter
-      // but the segment iterator doesn't include it
       if (f.iterator.asScala.count(_.startsWith("..")) > f.getNameCount / 2) {
         throw PathError.AbsolutePathOutsideRoot
       }

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -441,6 +441,7 @@ object Path {
       }
     }
   }
+
   /**
    * @return true if Windows OS and path begins with slash or backslash.
    * Examples:
@@ -458,11 +459,12 @@ object Path {
       }
     }
   }
+
   /**
    * @return current working drive if Windows, empty string elsewhere.
    */
   val platformPrefix: String = Paths.get(".").toAbsolutePath.getRoot.toString match {
-    case "/" => ""   // implies a non-Windows platform
+    case "/" => "" // implies a non-Windows platform
     case s => s"$s/" // Windows current working drive
   }
 }

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -24,7 +24,7 @@ object PathTests extends TestSuite {
         // Paths.get(driveRoot) same file as pwd
         val p1 = posix(Paths.get(driveRoot).toAbsolutePath) match {
           case s if s.matches(".:.*/") =>
-            s.stripSuffix("/") // java 8, remove spurious trailing slash 
+            s.stripSuffix("/") // java 8, remove spurious trailing slash
           case s =>
             s
         }

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -7,47 +7,52 @@ import os.Path.{platformPrefix}
 import utest.{assert => _, _}
 import java.net.URI
 object PathTests extends TestSuite {
-  def enableTest = true
   val tests = Tests {
     test("Basic") {
       val base = rel / "src" / "main" / "scala"
       val subBase = sub / "src" / "main" / "scala"
+      test("Transform posix paths"){
+        // verify posix string format of rootRelative path
+        assert(posix(root / "omg") == posix(Paths.get("/omg").toAbsolutePath))
+
+        // verify rootRelative path
+        assert(sameFile((root / "omg").wrapped, Paths.get("/omg")))
+     
+        // rootRelative path is an absolute path
+        assert(posix(root / "omg") == s"$platformPrefix/omg")
+    
+        // Paths.get(platformPrefix) same as pwd (not intuitively obvious)
+        assert(Paths.get(platformPrefix).toAbsolutePath == pwd.toNIO)
+      }
       test("Transformers") {
-        if (enableTest) {
-          // compare os.Path to java.nio.file.Path
-          assert((root / "omg").norm == Paths.get("/omg").norm)
-          assert(sameFile((root / "omg").wrapped, Paths.get("/omg")))
+        // java.nio.file.Path to os.Path
+        assert(root / "omg" == Path(Paths.get("/omg")))
+        assert(rel / "omg" == RelPath(Paths.get("omg")))
+        assert(sub / "omg" == SubPath(Paths.get("omg")))
 
-          // java.nio.file.Path to os.Path
-          assert(root / "omg" == Path(Paths.get("/omg")))
-          assert(rel / "omg" == RelPath(Paths.get("omg")))
-          assert(sub / "omg" == SubPath(Paths.get("omg")))
+        // URI to os.Path
+        assert(root / "omg" == Path(Paths.get("/omg").toUri()))
 
-          // URI to os.Path
-          assert(root / "omg" == Path(Paths.get("/omg").toUri()))
+        // We only support file schemes like above, but nothing else
+        val httpUri = URI.create(
+          "https://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top"
+        )
+        val ldapUri = URI.create(
+          "ldap://[2001:db8::7]/c=GB?objectClass?one"
+        )
+        intercept[IllegalArgumentException](Path(httpUri))
+        intercept[IllegalArgumentException](Path(ldapUri))
 
-          // We only support file schemes like above, but nothing else
-          val httpUri = URI.create(
-            "https://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top"
-          )
-          val ldapUri = URI.create(
-            "ldap://[2001:db8::7]/c=GB?objectClass?one"
-          )
-          intercept[IllegalArgumentException](Path(httpUri))
-          intercept[IllegalArgumentException](Path(ldapUri))
+        // os.Path to String
+        assert((rel / "omg").toString == "omg")
+        assert((sub / "omg").toString == "omg")
+        assert((up / "omg").toString == "../omg")
+        assert((up / up / "omg").toString == "../../omg")
 
-          // os.Path to String
-          assert((root / "omg").posix == s"$platformPrefix/omg")
-          assert((rel / "omg").toString == "omg")
-          assert((sub / "omg").toString == "omg")
-          assert((up / "omg").toString == "../omg")
-          assert((up / up / "omg").toString == "../../omg")
-
-          // String to os.Path
-          assert(root / "omg" == Path("/omg"))
-          assert(rel / "omg" == RelPath("omg"))
-          assert(sub / "omg" == SubPath("omg"))
-        }
+        // String to os.Path
+        assert(root / "omg" == Path("/omg"))
+        assert(rel / "omg" == RelPath("omg"))
+        assert(sub / "omg" == SubPath("omg"))
       }
 
       test("BasePath") {
@@ -87,22 +92,18 @@ object PathTests extends TestSuite {
       test("RelPath") {
         test("Constructors") {
           test("Symbol") {
-            if (enableTest) {
-              val rel1 = base / "ammonite"
-              assert(
-                rel1.segments == Seq("src", "main", "scala", "ammonite"),
-                rel1.toString == "src/main/scala/ammonite"
-              )
-            }
+            val rel1 = base / "ammonite"
+            assert(
+              rel1.segments == Seq("src", "main", "scala", "ammonite"),
+              rel1.toString == "src/main/scala/ammonite"
+            )
           }
           test("String") {
-            if (enableTest) {
-              val rel1 = base / "Path.scala"
-              assert(
-                rel1.segments == Seq("src", "main", "scala", "Path.scala"),
-                rel1.toString == "src/main/scala/Path.scala"
-              )
-            }
+            val rel1 = base / "Path.scala"
+            assert(
+              rel1.segments == Seq("src", "main", "scala", "Path.scala"),
+              rel1.toString == "src/main/scala/Path.scala"
+            )
           }
           test("Combos") {
             def check(rel1: RelPath) = assert(
@@ -110,29 +111,23 @@ object PathTests extends TestSuite {
               rel1.toString == "src/main/scala/sub1/sub2"
             )
             test("ArrayString") {
-              if (enableTest) {
-                val arr = Array("sub1", "sub2")
-                check(base / arr)
-              }
+              val arr = Array("sub1", "sub2")
+              check(base / arr)
             }
             test("ArraySymbol") {
-              if (enableTest) {
-                val arr = Array("sub1", "sub2")
-                check(base / arr)
-              }
+              val arr = Array("sub1", "sub2")
+              check(base / arr)
             }
             test("SeqString") {
-              if (enableTest) check(base / Seq("sub1", "sub2"))
+              check(base / Seq("sub1", "sub2"))
             }
             test("SeqSymbol") {
-              if (enableTest) check(base / Seq("sub1", "sub2"))
+              check(base / Seq("sub1", "sub2"))
             }
             test("SeqSeqSeqSymbol") {
-              if (enableTest) {
-                check(
-                  base / Seq(Seq(Seq("sub1"), Seq()), Seq(Seq("sub2")), Seq())
-                )
-              }
+              check(
+                base / Seq(Seq(Seq("sub1"), Seq()), Seq(Seq("sub2")), Seq())
+              )
             }
           }
         }
@@ -151,22 +146,18 @@ object PathTests extends TestSuite {
       test("SubPath") {
         test("Constructors") {
           test("Symbol") {
-            if (enableTest) {
-              val rel1 = subBase / "ammonite"
-              assert(
-                rel1.segments == Seq("src", "main", "scala", "ammonite"),
-                rel1.toString == "src/main/scala/ammonite"
-              )
-            }
+            val rel1 = subBase / "ammonite"
+            assert(
+              rel1.segments == Seq("src", "main", "scala", "ammonite"),
+              rel1.toString == "src/main/scala/ammonite"
+            )
           }
           test("String") {
-            if (enableTest) {
-              val rel1 = subBase / "Path.scala"
-              assert(
-                rel1.segments == Seq("src", "main", "scala", "Path.scala"),
-                rel1.toString == "src/main/scala/Path.scala"
-              )
-            }
+            val rel1 = subBase / "Path.scala"
+            assert(
+              rel1.segments == Seq("src", "main", "scala", "Path.scala"),
+              rel1.toString == "src/main/scala/Path.scala"
+            )
           }
           test("Combos") {
             def check(rel1: SubPath) = assert(
@@ -174,29 +165,23 @@ object PathTests extends TestSuite {
               rel1.toString == "src/main/scala/sub1/sub2"
             )
             test("ArrayString") {
-              if (enableTest) {
-                val arr = Array("sub1", "sub2")
-                check(subBase / arr)
-              }
+              val arr = Array("sub1", "sub2")
+              check(subBase / arr)
             }
             test("ArraySymbol") {
-              if (enableTest) {
-                val arr = Array("sub1", "sub2")
-                check(subBase / arr)
-              }
+              val arr = Array("sub1", "sub2")
+              check(subBase / arr)
             }
             test("SeqString") {
-              if (enableTest) check(subBase / Seq("sub1", "sub2"))
+              check(subBase / Seq("sub1", "sub2"))
             }
             test("SeqSymbol") {
-              if (enableTest) check(subBase / Seq("sub1", "sub2"))
+              check(subBase / Seq("sub1", "sub2"))
             }
             test("SeqSeqSeqSymbol") {
-              if (enableTest) {
-                check(
-                  subBase / Seq(Seq(Seq("sub1"), Seq()), Seq(Seq("sub2")), Seq())
-                )
-              }
+              check(
+                subBase / Seq(Seq(Seq("sub1"), Seq()), Seq(Seq("sub2")), Seq())
+              )
             }
           }
         }
@@ -214,7 +199,7 @@ object PathTests extends TestSuite {
         val abs = d / base
         test("Constructor") {
           assert(
-            abs.posix.drop(d.toString.length) == "/src/main/scala",
+            posix(abs).drop(d.toString.length) == "/src/main/scala",
             abs.toString.length > d.toString.length
           )
         }
@@ -310,22 +295,18 @@ object PathTests extends TestSuite {
         intercept[PathError.InvalidSegment](rel / "src" / "..")
       }
       test("CannotRelativizeAbsAndRel") {
-        if (enableTest) {
-          val abs = pwd
-          val rel = os.rel / "omg" / "wtf"
-          compileError("""
-          abs.relativeTo(rel)
-        """).msg.toLowerCase.contains("required: os.path") ==> true
-          compileError("""
-          rel.relativeTo(abs)
-        """).msg.toLowerCase.contains("required: os.relpath") ==> true
-        }
+        val abs = pwd
+        val rel = os.rel / "omg" / "wtf"
+        compileError("""
+        abs.relativeTo(rel)
+      """).msg.toLowerCase.contains("required: os.path") ==> true
+        compileError("""
+        rel.relativeTo(abs)
+      """).msg.toLowerCase.contains("required: os.relpath") ==> true
       }
       test("InvalidCasts") {
-        if (enableTest) {
-          intercept[IllegalArgumentException](Path("omg/cow"))
-          intercept[IllegalArgumentException](RelPath("/omg/cow"))
-        }
+        intercept[IllegalArgumentException](Path("omg/cow"))
+        intercept[IllegalArgumentException](RelPath("/omg/cow"))
       }
       test("Pollution") {
         // Make sure we"re" not polluting too much
@@ -369,66 +350,58 @@ object PathTests extends TestSuite {
     }
     test("construction") {
       test("success") {
-        if (enableTest) {
-          val relStr = "hello/cow/world/.."
-          val absStr = "/hello/world"
+        val relStr = "hello/cow/world/.."
+        val absStr = "/hello/world"
 
-          val lhs = Path(absStr)
-          val rhs = root / "hello" / "world"
-          assert(
-            RelPath(relStr) == rel / "hello" / "cow",
-            // Path(...) also allows paths starting with ~,
-            // which is expanded to become your home directory
-            lhs == rhs
-          )
+        val lhs = Path(absStr)
+        val rhs = root / "hello" / "world"
+        assert(
+          RelPath(relStr) == rel / "hello" / "cow",
+          // Path(...) also allows paths starting with ~,
+          // which is expanded to become your home directory
+          lhs == rhs
+        )
 
-          // You can also pass in java.io.File and java.nio.file.Path
-          // objects instead of Strings when constructing paths
-          val relIoFile = new java.io.File(relStr)
-          val absNioFile = java.nio.file.Paths.get(absStr)
+        // You can also pass in java.io.File and java.nio.file.Path
+        // objects instead of Strings when constructing paths
+        val relIoFile = new java.io.File(relStr)
+        val absNioFile = java.nio.file.Paths.get(absStr)
 
-          assert(RelPath(relIoFile) == rel / "hello" / "cow")
-          assert(Path(absNioFile) == root / "hello" / "world")
-          assert(Path(relIoFile, root / "base") == root / "base" / "hello" / "cow")
-        }
+        assert(RelPath(relIoFile) == rel / "hello" / "cow")
+        assert(Path(absNioFile) == root / "hello" / "world")
+        assert(Path(relIoFile, root / "base") == root / "base" / "hello" / "cow")
       }
       test("basepath") {
-        if (enableTest) {
-          val relStr = "hello/cow/world/.."
-          val absStr = "/hello/world"
-          assert(
-            FilePath(relStr) == rel / "hello" / "cow",
-            FilePath(absStr) == root / "hello" / "world"
-          )
-        }
+        val relStr = "hello/cow/world/.."
+        val absStr = "/hello/world"
+        assert(
+          FilePath(relStr) == rel / "hello" / "cow",
+          FilePath(absStr) == root / "hello" / "world"
+        )
       }
       test("based") {
-        if (enableTest) {
-          val relStr = "hello/cow/world/.."
-          val absStr = "/hello/world"
-          val basePath: FilePath = FilePath(relStr)
-          assert(Path(relStr, root / "base") == root / "base" / "hello" / "cow")
-          assert(Path(absStr, root / "base") == root / "hello" / "world")
-          assert(Path(basePath, root / "base") == root / "base" / "hello" / "cow")
-          assert(Path(".", pwd).last != "")
-        }
+        val relStr = "hello/cow/world/.."
+        val absStr = "/hello/world"
+        val basePath: FilePath = FilePath(relStr)
+        assert(Path(relStr, root / "base") == root / "base" / "hello" / "cow")
+        assert(Path(absStr, root / "base") == root / "hello" / "world")
+        assert(Path(basePath, root / "base") == root / "base" / "hello" / "cow")
+        assert(Path(".", pwd).last != "")
       }
       test("failure") {
-        if (enableTest) {
-          val relStr = "hello/.."
-          intercept[java.lang.IllegalArgumentException] {
-            Path(relStr)
-          }
+        val relStr = "hello/.."
+        intercept[java.lang.IllegalArgumentException] {
+          Path(relStr)
+        }
 
-          val absStr = "/hello"
-          intercept[java.lang.IllegalArgumentException] {
-            RelPath(absStr)
-          }
+        val absStr = "/hello"
+        intercept[java.lang.IllegalArgumentException] {
+          RelPath(absStr)
+        }
 
-          val tooManyUpsStr = "/hello/../.."
-          intercept[PathError.AbsolutePathOutsideRoot.type] {
-            Path(tooManyUpsStr)
-          }
+        val tooManyUpsStr = "/hello/../.."
+        intercept[PathError.AbsolutePathOutsideRoot.type] {
+          Path(tooManyUpsStr)
         }
       }
     }
@@ -440,7 +413,9 @@ object PathTests extends TestSuite {
       assert(result2 == expected)
     }
     test("issue201") {
-      Path("/omg") // rootRelative path does not throw exception.
+      val p = Path("/omg") // rootRelative path does not throw exception.
+      System.err.printf("p[%s]\n", posix(p))
+      assert(posix(p) contains "/omg")
     }
   }
   // compare absolute paths
@@ -453,20 +428,7 @@ object PathTests extends TestSuite {
   def sameFile(a: Path, b: Path): Boolean = {
     sameFile(a.wrapped, b.wrapped)
   }
-  implicit class ExtendString(s: String) {
-    def posix: String = s.replace('\\', '/')
-    def norm: String = if (s.startsWith(platformPrefix)) {
-      s.posix // already has platformPrefix
-    } else {
-      s"$platformPrefix${s.posix}"
-    }
-  }
-  implicit class ExtendOsPath(p: os.Path) {
-    def posix: String = p.toNIO.toString.posix
-    def norm: String = p.toString.norm
-  }
-  implicit class ExtendPath(p: java.nio.file.Path) {
-    def posix: String = p.toString.posix
-    def norm: String = p.toString.norm
-  }
+  def posix(s: String): String = s.replace('\\', '/')
+  def posix(p: java.nio.file.Path): String = posix(p.toString)
+  def posix(p: os.Path): String = posix(p.toNIO)
 }

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -6,12 +6,15 @@ import os._
 import utest.{assert => _, _}
 import java.net.URI
 object PathTests extends TestSuite {
+  val wintest = Option(System.getenv("WINPATHTEST")).nonEmpty
+  def enableTest = Unix() || wintest
   val tests = Tests {
     test("Basic") {
       val base = rel / "src" / "main" / "scala"
       val subBase = sub / "src" / "main" / "scala"
+      def norm(s: String) = s.replace('\\', '/')
       test("Transformers") {
-        if (Unix()) {
+        if (enableTest) {
           // os.Path to java.nio.file.Path
           assert((root / "omg").wrapped == Paths.get("/omg"))
 
@@ -84,7 +87,7 @@ object PathTests extends TestSuite {
       test("RelPath") {
         test("Constructors") {
           test("Symbol") {
-            if (Unix()) {
+            if (enableTest) {
               val rel1 = base / "ammonite"
               assert(
                 rel1.segments == Seq("src", "main", "scala", "ammonite"),
@@ -93,7 +96,7 @@ object PathTests extends TestSuite {
             }
           }
           test("String") {
-            if (Unix()) {
+            if (enableTest) {
               val rel1 = base / "Path.scala"
               assert(
                 rel1.segments == Seq("src", "main", "scala", "Path.scala"),
@@ -107,25 +110,25 @@ object PathTests extends TestSuite {
               rel1.toString == "src/main/scala/sub1/sub2"
             )
             test("ArrayString") {
-              if (Unix()) {
+              if (enableTest) {
                 val arr = Array("sub1", "sub2")
                 check(base / arr)
               }
             }
             test("ArraySymbol") {
-              if (Unix()) {
+              if (enableTest) {
                 val arr = Array("sub1", "sub2")
                 check(base / arr)
               }
             }
             test("SeqString") {
-              if (Unix()) check(base / Seq("sub1", "sub2"))
+              if (enableTest) check(base / Seq("sub1", "sub2"))
             }
             test("SeqSymbol") {
-              if (Unix()) check(base / Seq("sub1", "sub2"))
+              if (enableTest) check(base / Seq("sub1", "sub2"))
             }
             test("SeqSeqSeqSymbol") {
-              if (Unix()) {
+              if (enableTest) {
                 check(
                   base / Seq(Seq(Seq("sub1"), Seq()), Seq(Seq("sub2")), Seq())
                 )
@@ -148,7 +151,7 @@ object PathTests extends TestSuite {
       test("SubPath") {
         test("Constructors") {
           test("Symbol") {
-            if (Unix()) {
+            if (enableTest) {
               val rel1 = subBase / "ammonite"
               assert(
                 rel1.segments == Seq("src", "main", "scala", "ammonite"),
@@ -157,7 +160,7 @@ object PathTests extends TestSuite {
             }
           }
           test("String") {
-            if (Unix()) {
+            if (enableTest) {
               val rel1 = subBase / "Path.scala"
               assert(
                 rel1.segments == Seq("src", "main", "scala", "Path.scala"),
@@ -171,25 +174,25 @@ object PathTests extends TestSuite {
               rel1.toString == "src/main/scala/sub1/sub2"
             )
             test("ArrayString") {
-              if (Unix()) {
+              if (enableTest) {
                 val arr = Array("sub1", "sub2")
                 check(subBase / arr)
               }
             }
             test("ArraySymbol") {
-              if (Unix()) {
+              if (enableTest) {
                 val arr = Array("sub1", "sub2")
                 check(subBase / arr)
               }
             }
             test("SeqString") {
-              if (Unix()) check(subBase / Seq("sub1", "sub2"))
+              if (enableTest) check(subBase / Seq("sub1", "sub2"))
             }
             test("SeqSymbol") {
-              if (Unix()) check(subBase / Seq("sub1", "sub2"))
+              if (enableTest) check(subBase / Seq("sub1", "sub2"))
             }
             test("SeqSeqSeqSymbol") {
-              if (Unix()) {
+              if (enableTest) {
                 check(
                   subBase / Seq(Seq(Seq("sub1"), Seq()), Seq(Seq("sub2")), Seq())
                 )
@@ -210,8 +213,8 @@ object PathTests extends TestSuite {
         val d = pwd
         val abs = d / base
         test("Constructor") {
-          if (Unix()) assert(
-            abs.toString.drop(d.toString.length) == "/src/main/scala",
+          if (enableTest) assert(
+            norm(abs.toString.drop(d.toString.length)) == "/src/main/scala",
             abs.toString.length > d.toString.length
           )
         }
@@ -307,7 +310,7 @@ object PathTests extends TestSuite {
         intercept[PathError.InvalidSegment](rel / "src" / "..")
       }
       test("CannotRelativizeAbsAndRel") {
-        if (Unix()) {
+        if (enableTest) {
           val abs = pwd
           val rel = os.rel / "omg" / "wtf"
           compileError("""
@@ -319,7 +322,7 @@ object PathTests extends TestSuite {
         }
       }
       test("InvalidCasts") {
-        if (Unix()) {
+        if (enableTest) {
           intercept[IllegalArgumentException](Path("omg/cow"))
           intercept[IllegalArgumentException](RelPath("/omg/cow"))
         }
@@ -366,7 +369,7 @@ object PathTests extends TestSuite {
     }
     test("construction") {
       test("success") {
-        if (Unix()) {
+        if (enableTest) {
           val relStr = "hello/cow/world/.."
           val absStr = "/hello/world"
 
@@ -390,7 +393,7 @@ object PathTests extends TestSuite {
         }
       }
       test("basepath") {
-        if (Unix()) {
+        if (enableTest) {
           val relStr = "hello/cow/world/.."
           val absStr = "/hello/world"
           assert(
@@ -400,7 +403,7 @@ object PathTests extends TestSuite {
         }
       }
       test("based") {
-        if (Unix()) {
+        if (enableTest) {
           val relStr = "hello/cow/world/.."
           val absStr = "/hello/world"
           val basePath: FilePath = FilePath(relStr)
@@ -411,7 +414,7 @@ object PathTests extends TestSuite {
         }
       }
       test("failure") {
-        if (Unix()) {
+        if (enableTest) {
           val relStr = "hello/.."
           intercept[java.lang.IllegalArgumentException] {
             Path(relStr)

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -22,7 +22,12 @@ object PathTests extends TestSuite {
         assert(posix(root / "omg") == s"$driveRoot/omg")
 
         // Paths.get(driveRoot) same file as pwd
-        val p1 = posix(Paths.get(driveRoot).toAbsolutePath)
+        val p1 = posix(Paths.get(driveRoot).toAbsolutePath) match {
+          case s if s.matches(".:.*/") =>
+            s.stripSuffix("/") // java 8, remove spurious trailing slash 
+          case s =>
+            s
+        }
         val p2 = posix(pwd.toNIO.toAbsolutePath)
         System.err.printf("p1[%s]\np2[%s]\n", p1, p2)
         assert(p1 == p2)
@@ -431,10 +436,7 @@ object PathTests extends TestSuite {
   def sameFile(a: Path, b: Path): Boolean = {
     sameFile(a.wrapped, b.wrapped)
   }
-  def posix(s: String): String = s.replace('\\', '/') match {
-    case "/" => "/"
-    case s => s.stripSuffix("/") // no traling suffix
-  }
+  def posix(s: String): String = s.replace('\\', '/')
   def posix(p: java.nio.file.Path): String = posix(p.toString)
   def posix(p: os.Path): String = posix(p.toNIO)
 }

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -21,11 +21,11 @@ object PathTests extends TestSuite {
         // rootRelative path is an absolute path
         assert(posix(root / "omg") == s"$platformPrefix/omg")
 
-        // Paths.get(platformPrefix) same as pwd (not intuitively obvious)
-        val p1 = Paths.get(platformPrefix).toAbsolutePath
+        // Paths.get(platformPrefix) same file as pwd
+        val p1 = Paths.get(platformPrefix)
         val p2 = pwd.toNIO
         System.err.printf("p1[%s]\np2[%s]\n", p1, p2)
-        assert(Paths.get(platformPrefix).toAbsolutePath == pwd.toNIO)
+        assert(sameFile(p1, p2))
       }
       test("Transformers") {
         // java.nio.file.Path to os.Path

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -11,17 +11,20 @@ object PathTests extends TestSuite {
     test("Basic") {
       val base = rel / "src" / "main" / "scala"
       val subBase = sub / "src" / "main" / "scala"
-      test("Transform posix paths"){
+      test("Transform posix paths") {
         // verify posix string format of rootRelative path
         assert(posix(root / "omg") == posix(Paths.get("/omg").toAbsolutePath))
 
         // verify rootRelative path
         assert(sameFile((root / "omg").wrapped, Paths.get("/omg")))
-     
+
         // rootRelative path is an absolute path
         assert(posix(root / "omg") == s"$platformPrefix/omg")
-    
+
         // Paths.get(platformPrefix) same as pwd (not intuitively obvious)
+        val p1 = Paths.get(platformPrefix).toAbsolutePath
+        val p2 = pwd.toNIO
+        System.err.printf("p1[%s]\np2[%s]\n", p1, p2)
         assert(Paths.get(platformPrefix).toAbsolutePath == pwd.toNIO)
       }
       test("Transformers") {


### PR DESCRIPTION
Thanks for a great library!   Hopefully this change will increase interest among windows shell environment developers.

This fixes #201

The essence of the fix is to support paths with a leading slash (`'/' or '\'`) on Windows.

In this PR, this path type is referred to as `driveRelative`, due to subtle differences in how it is handled on `Windows` versus other platforms.

Example code:
```scala
    val p1 = java.nio.file.Paths.get("/omg")
    printf("isAbsolute: %s\n", p1.isAbsolute)
    printf("%s\n", p1)
    printf("%s\n", os.Path("/omg"))
```
Output on Linux or OSX:
```sh
isAbsolute: true
/omg
/omg
```
On Windows:
```scala
isAbsolute: false
\omg
java.lang.IllegalArgumentException: requirement failed: \omg is not an absolute path
        at os.Path.<init>(Path.scala:474)
        at os.Path$.apply(Path.scala:426)
        at oslibChek$package$.main(oslibChek.sc:11)
        at oslibChek$package.main(oslibChek.sc)
```
### Background
On Windows, a `driveRelative` path is considered relative because a drive letter prefix is required to fully resolve it.
Like other platforms, Windows also supports `posix relative` paths, which are relative to the `current working directory`.

Because all platforms, including `Windows`, support absolute paths and `posix relative` paths, it's convenient when writing platform-independent code to view `driveRelative` paths as absolute paths, as they are on other platforms.

On Windows, the `current working drive` is an immutable value that is captured on jvm startup.  Therefore, a `driveRelative` path on Windows unambiguously refers to a unique file with a hidden drive letter.

This PR treats `driveRelative` paths as absolute paths in Windows, and has no effect on other platforms.

#### Making `os/test/src/PathTests` platform independent

This PR enables `Unix()` tests in `os/test/src/PathTests.scala`  so they also verify required semantics in Windows.

### How this PR relates to #170 and #196
The purpose of #196 seems to be to add full support on Windows, without resorting to `java.nio` classes and methods.
The addition of `os.root(...)` or `os.drive(...)` would be convenient for people writing windows-only code, whereas this PR is intended to allow writing platform-independent code, so the concerns seem to be orthogonal. 

It seems important not to alter `Path.segments` in a way that is incompatible with `java.nio` segments.
 
An alternate way to preserve drive letter information would be to add a method to one of the `Path.scala` traits that returns a drive letter if appropriate on `Windows` and an empty String elsewhere.

```scala
trait PathChunk {
  def segments: Seq[String]
  def rootPrefix: String  // empty String, or Windows drive letter
  def ups: Int
}
```

With this approach, the following assertion would be valid on all platforms:

```scala
os.Path(pwd.rootPrefix) ==> pwd
```

Then `driveRoot` in this PR would become `pwd.rootPrefix`.

There is another (perhaps never used?) very subtle feature of `Windows` filesystem:  each drive has a different value for `pwd`.   It may not be necessary to model this in `os-lib`, since these values are immutable in a running jvm, and there are existing workarounds.


### Additional Details regarding unique aspects of Windows Filesystem Paths
For completeness, the following lengthy `scala` REPL session illustrates Path values returned by `java.nio.file.Paths.get()`, some of which might be surprising.
<details>

Relevant information: My system drives are C: and F:, but not J:

First, some unsurprising results:
```scala
c:\work-directory> scala.bat
scala> import java.nio.file.Paths
Welcome to Scala 3.3.1-RC5 (17.0.2, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> Paths.get("/")
val res0: java.nio.file.Path = \

scala> Paths.get("/").isAbsolute
val res2: Boolean = false

scala> Paths.get("/").toAbsolutePath
val res1: java.nio.file.Path = C:\

scala> Paths.get("c:/").toAbsolutePath
C:\work-directory

scala> Paths.get("f:/").toAbsolutePath
F:\

scala> Paths.get("f:/..").normalize.toAbsolutePath
f:\

scala> Paths.get("c:/..").normalize.toAbsolutePath
c:\
```
Now some less obvious results:
```scala
scala> Paths.get("c:").toAbsolutePath
C:\work-directory

scala> Paths.get("f:").toAbsolutePath
F:\

scala> Paths.get("f:/..").normalize.toAbsolutePath
f:\

scala> Paths.get("c:/..").normalize.toAbsolutePath
c:\

scala> Paths.get("c:..").normalize.toAbsolutePath
C:\work-directory

scala> Paths.get("f:..").normalize.toAbsolutePath
F:\..

scala> Paths.get("F:Users")
val res1: java.nio.file.Path = F:Users

scala> Paths.get("F:Users").toAbsolutePath
val res2: java.nio.file.Path = F:\work-directory\Users

scala> Paths.get("j:").toAbsolutePath
java.io.IOError: java.io.IOException: Unable to get working directory of drive 'J'
  at java.base/sun.nio.fs.WindowsPath.toAbsolutePath(WindowsPath.java:926)
  at java.base/sun.nio.fs.WindowsPath.toAbsolutePath(WindowsPath.java:42)
  ... 35 elided
Caused by: java.io.IOException: Unable to get working directory of drive 'J'
  ... 37 more
```

The error message returned for a non-existing drive  seems to imply that existing drives have a `working directory`.
This is consistent with the `Windows API` as described here:
[GetFullPathNameA](https://learn.microsoft.com/en-gb/windows/win32/api/fileapi/nf-fileapi-getfullpathnamea)

I can set the `working drive` for F: in a `CMD` session before I start up the `jvm`, and it does affect the output of `Paths.get()`.
```CMD
c:\work-directory>F:

f:\>cd work-directory

F:\work-directory>scala.bat
Welcome to Scala 3.3.1-RC5 (17.0.2, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> import java.nio.file.Paths

scala> Paths.get("/")
val res0: java.nio.file.Path = \

scala> Paths.get("/").toAbsolutePath
val res1: java.nio.file.Path = C:\

scala> Paths.get("f:")
val res2: java.nio.file.Path = f:

scala> Paths.get("f:").toAbsolutePath
val res3: java.nio.file.Path = F:\work-directory

scala> Paths.get("c:").toAbsolutePath
val res4: java.nio.file.Path = C:\work-directory

scala> Paths.get("c:")
val res5: java.nio.file.Path = c:
```

Regarding the interpretation of a drive letter expression not followed by a '/' or '\\', the
rule is that it represents the `working directory` for that drive.

These values are immutable: after the `JVM` starts up it's not possible to change a drive `working directory`.
</details>

