### PR TITLE
os.proc.call: replace reference to Chunk(/ByteData).string() with text()

### DIFF
--- a/os/src-jvm/ProcessOps.scala
+++ b/os/src-jvm/ProcessOps.scala
@@ -27,7 +27,7 @@ case class proc(command: Shellable*) {
   /**
    * Invokes the given subprocess like a function, passing in input and returning a
    * [[CommandResult]]. You can then call `result.exitCode` to see how it exited, or
-   * `result.out.bytes` or `result.err.string` to access the aggregated stdout and
+   * `result.out.bytes` or `result.err.text()` to access the aggregated stdout and
    * stderr of the subprocess in a number of convenient ways. If a non-zero exit code
    * is returned, this throws a [[os.SubprocessException]] containing the
    * [[CommandResult]], unless you pass in `check = false`.


### PR DESCRIPTION
The .string() method in geny's ByteData was removed [1].

1: https://github.com/com-lihaoyi/geny/commit/d1289bc020e79df9482c2cb46c65a1c41511c24b