### PR TITLE
Add external mappings for scaladoc

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -89,6 +89,23 @@ trait OsModule extends OsLibModule { outer =>
   def ivyDeps = Agg(Deps.geny)
 
   def artifactName = "os-lib"
+
+  val scalaDocExternalMappings = Seq(
+    ".*scala.*::scaladoc3::https://scala-lang.org/api/3.x/",
+    ".*java.*::javadoc::https://docs.oracle.com/javase/8/docs/api/",
+    s".*geny.*::scaladoc3::https://javadoc.io/doc/com.lihaoyi/geny_3/${Deps.geny.dep.version}/",
+  ).mkString(",")
+
+  def conditionalScalaDocOptions: T[Seq[String]] = T {
+    if (ZincWorkerUtil.isDottyOrScala3(scalaVersion()))
+      Seq(
+        s"-external-mappings:${scalaDocExternalMappings}"
+      )
+    else Seq()
+  }
+
+  def scalaDocOptions = super.scalaDocOptions() ++ conditionalScalaDocOptions()
+
 }
 
 object os extends Module {


### PR DESCRIPTION
External mappings allow linking to other project's documentation, which makes it easier for users to understand the API.

This is a WIP. The main thing to address is that the place where we set scalaDocOptions may be not correct, I could imagine that it should be done in `OsJvmModule`. Furthermore, I should be only set if `scaladoc` from Scala 3 is used, as the `-external`mappings` option is only available from there on. Unfortunately, I lack the mill and os-lib build system knowledge to proceed here. Any feedback would be appreciated.