### PR TITLE
Disable explicit TOC rendering in readme

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -1,8 +1,5 @@
 = OS-Lib
 :version: 0.9.1
-:toc-placement: preamble
-:toclevels: 3
-:toc:
 :link-geny: https://github.com/com-lihaoyi/geny
 :link-oslib: https://github.com/com-lihaoyi/os-lib
 :link-oslib-gitter: https://gitter.im/lihaoyi/os-lib


### PR DESCRIPTION
Latest changes in GitHub make some TOC links no longer work. Also, GitHub now always has a somewhat hidden TOC in the upper left corner of the readme, so I think a TOC wih non-working links isn't useful.

Fix: https://github.com/com-lihaoyi/os-lib/issues/220
Supersedes: https://github.com/com-lihaoyi/os-lib/issues/181

Pull request: https://github.com/com-lihaoyi/os-lib/pull/222