### PR TITLE
fix for Windows os.root() with slash error

### DIFF
--- a/os/src-jvm/package.scala
+++ b/os/src-jvm/package.scala
@@ -15,7 +15,7 @@ package object os {
 
   def root(root: String, fileSystem: FileSystem = FileSystems.getDefault()): Path = {
     val path = Path(fileSystem.getPath(root))
-    assert(path.root == root, s"$root is not a root path")
+    assert(path.root == root || path.root == root.replace('/', '\\'), s"$root is not a root path")
     path
   }
 

--- a/os/src-native/package.scala
+++ b/os/src-native/package.scala
@@ -12,7 +12,7 @@ package object os {
 
   def root(root: String, fileSystem: FileSystem = FileSystems.getDefault()): Path = {
     val path = Path(fileSystem.getPath(root))
-    assert(path.root == root, s"$root is not a root path")
+    assert(path.root == root || path.root == root.replace('/', '\\'), s"$root is not a root path")
     path
   }
 

--- a/os/test/src-jvm/PathTestsCustomFilesystem.scala
+++ b/os/test/src-jvm/PathTestsCustomFilesystem.scala
@@ -226,8 +226,10 @@ object PathTestsCustomFilesystem extends TestSuite {
 
   val testWindows = Tests {
     test("cRootPath") {
-      val p = os.root("C:\\") / "Users"
-      assert(p.toString == "C:\\Users")
+      val p1 = os.root("C:\\") / "Users"
+      assert(p1.toString == "C:\\Users")
+      val p2 = os.root("C:/") / "Users"
+      assert(p2.toString == "C:\\Users")
     }
   }
 


### PR DESCRIPTION
This fixes #234 and adds a unit test.

