### PR TITLE
Make os.home lazy

### DIFF
--- a/os/src-jvm/package.scala
+++ b/os/src-jvm/package.scala
@@ -26,7 +26,7 @@ package object os {
   /**
    * The user's home directory
    */
-  val home: Path = Path(System.getProperty("user.home"))
+  lazy val home: Path = Path(System.getProperty("user.home"))
 
   /**
    * The current working directory for this process.

--- a/os/src-native/package.scala
+++ b/os/src-native/package.scala
@@ -19,7 +19,7 @@ package object os {
   /**
    * The user's home directory
    */
-  val home: Path = Path(System.getProperty("user.home"))
+  lazy val home: Path = Path(System.getProperty("user.home"))
 
   /**
    * The current working directory for this process.

--- a/os/test/src/OpTests.scala
+++ b/os/test/src/OpTests.scala
@@ -34,5 +34,15 @@ object OpTests extends TestSuite {
         os.remove(os.pwd / "out" / "scratch" / "nonexistent", checkExists = true)
       }
     }
+    test("pwd when home is not available") {
+      val correctPwd = java.nio.file.Paths.get(".").toAbsolutePath
+      val oldUserHome = System.getProperty("user.home")
+      System.setProperty("user.home", "?")
+      try {
+        assert(os.pwd == os.Path(correctPwd))
+      } finally {
+        System.setProperty("user.home", oldUserHome)
+      }
+    }
   }
 }


### PR DESCRIPTION
In some environments the home directory is not configured, thus `user.home` can be set to e.g. "?" (like in the issue the Scala CLI team has bumped into). See [OpenJDK sources](https://github.com/openjdk/jdk/blob/master/src/java.base/unix/native/libjava/java_props_md.c#L508)

In those cases using e.g. `os.pwd` throws, since the `os.home` is also initialized.
This fix allows `os.pwd` to still be used when `user.home` is set to something weird.