### PR TITLE
Fix artifactName for os-lib-watch

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -139,6 +139,7 @@ object os extends Module {
   object watch extends Module {
     object jvm extends Cross[WatchJvmModule](scalaVersions)
     trait WatchJvmModule extends OsLibModule {
+      def artifactName = "os-lib-watch"
       def moduleDeps = super.moduleDeps ++ Seq(os.jvm())
       def ivyDeps = Agg(Deps.jna)
       object test extends ScalaTests with OsLibTestModule {


### PR DESCRIPTION
Probably during the update of Mill to 0.11 the `artifactName` of `os-lib-watch` was not set correctly, changing it to `os-watch`.