### PR TITLE
Make os.Path and os.RelPath implement CharSequence

### DIFF
--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -234,9 +234,13 @@ object PathError {
  * relative [[RelPath]], and can be constructed from a
  * java.nio.file.Path or java.io.File
  */
-sealed trait FilePath extends BasePath {
+sealed trait FilePath extends BasePath with CharSequence {
   def toNIO: java.nio.file.Path
   def resolveFrom(base: os.Path): os.Path
+
+  override def charAt(index: Int): Char = toString().charAt(index)
+  override def subSequence(start: Int, end: Int): CharSequence = toString().subSequence(start, end)
+  override def length(): Int = toString.length()
 }
 
 object FilePath {


### PR DESCRIPTION
Having os.Path and os.RelPath, in fact os.FilePath, implement CharSequence reduces the boilerplate when using functions that take a input collection and produce some form of textual output.

Consider the following example

```scala
def printBashArray(out: Appendable, name: String, content: Seq[CharSequence]) =
  out.append(f"${name}=(\n")
  for c <- content
  do out.append(f"\t${c}\n")
  out.append(")\n")
```

and

```scala
val fooPaths: Seq[os.RelPath]
```

Currently we have to

```scala
printBashArray(out, "FOO_PATHS", fooPaths.map(_.toString))
```

after this change, we can simply

```scala
printBashArray(out, "FOO_PATHS", fooPaths)
```

(Of course, we could also declare 'content' as Seq[Any], but this blurres the intention.)