### PR TITLE
Fix os.copy and os.move directories to root

### DIFF
--- a/os/src/FileOps.scala
+++ b/os/src/FileOps.scala
@@ -84,7 +84,7 @@ object move {
       atomicMove: Boolean = false,
       createFolders: Boolean = false
   ): Unit = {
-    if (createFolders) makeDir.all(to / up)
+    if (createFolders && to.segmentCount != 0) makeDir.all(to / up)
     val opts1 =
       if (replaceExisting) Array[CopyOption](StandardCopyOption.REPLACE_EXISTING)
       else Array[CopyOption]()
@@ -176,7 +176,7 @@ object copy {
       createFolders: Boolean = false,
       mergeFolders: Boolean = false
   ): Unit = {
-    if (createFolders) makeDir.all(to / up)
+    if (createFolders && to.segmentCount != 0) makeDir.all(to / up)
     val opts1 =
       if (followLinks) Array[CopyOption]()
       else Array[CopyOption](LinkOption.NOFOLLOW_LINKS)

--- a/os/src/FileOps.scala
+++ b/os/src/FileOps.scala
@@ -68,7 +68,7 @@ object move {
       def isDefinedAt(x: Path) = partialFunction.isDefinedAt(x)
       def apply(from: Path) = {
         val dest = partialFunction(from)
-        makeDir.all(dest / up)
+        if (dest.segmentCount != 0) makeDir.all(dest / up)
         os.move(from, dest, replaceExisting, atomicMove, createFolders)
       }
     }
@@ -149,7 +149,7 @@ object copy {
       def isDefinedAt(x: Path) = partialFunction.isDefinedAt(x)
       def apply(from: Path) = {
         val dest = partialFunction(from)
-        makeDir.all(dest / up)
+        if (dest.segmentCount != 0) makeDir.all(dest / up)
         os.copy(
           from,
           dest,

--- a/os/test/src-jvm/PathTestsCustomFilesystem.scala
+++ b/os/test/src-jvm/PathTestsCustomFilesystem.scala
@@ -214,7 +214,8 @@ object PathTestsCustomFilesystem extends TestSuite {
             os.list(os.root("/", fileSystem)).collect(os.move.matching { case p / "test" => p })
           } match {
             // This is expected. We just test that it doesn't throw PathError.AbsolutePathOutsideRoot.
-            case Failure(e @(_: IllegalArgumentException | _: FileAlreadyExistsException)) => e.getMessage
+            case Failure(e @ (_: IllegalArgumentException | _: FileAlreadyExistsException)) =>
+              e.getMessage
           }
         }
       }

--- a/os/test/src-jvm/PathTestsCustomFilesystem.scala
+++ b/os/test/src-jvm/PathTestsCustomFilesystem.scala
@@ -206,13 +206,11 @@ object PathTestsCustomFilesystem extends TestSuite {
           assert(os.exists(root / "file.txt"))
         }
       }
-      test("moveMatchingToRootDirectory") {
+      test("moveMatchingToRootDirectoryShouldFail") {
         withCustomFs { fileSystem =>
-          try {
+          // This should fail. Just test that it doesn't throw PathError.AbsolutePathOutsideRoot.
+          intercept[FileAlreadyExistsException] {
             os.list(os.root("/", fileSystem)).collect(os.move.matching { case p / "test" => p })
-          } catch {
-            case e: PathError.AbsolutePathOutsideRoot.type => throw e
-            case NonFatal(_) => ()
           }
         }
       }

--- a/os/test/src-jvm/PathTestsCustomFilesystem.scala
+++ b/os/test/src-jvm/PathTestsCustomFilesystem.scala
@@ -213,8 +213,8 @@ object PathTestsCustomFilesystem extends TestSuite {
           Try {
             os.list(os.root("/", fileSystem)).collect(os.move.matching { case p / "test" => p })
           } match {
-            // This is expected. We just test that it doesn't throw PathError.AbsolutePathOutsideRoot.
-            case Failure(e @ (_: IllegalArgumentException | _: FileAlreadyExistsException)) =>
+            case Failure(e @ (_: IllegalArgumentException | _: FileAlreadyExistsException))
+                if !e.isInstanceOf[PathError.AbsolutePathOutsideRoot.type] =>
               e.getMessage
           }
         }

--- a/os/test/src-jvm/PathTestsCustomFilesystem.scala
+++ b/os/test/src-jvm/PathTestsCustomFilesystem.scala
@@ -198,6 +198,28 @@ object PathTestsCustomFilesystem extends TestSuite {
           }
         }
       }
+      test("copyMatchingAndMergeToRootDirectory") {
+        withCustomFs { fileSystem =>
+          val root = os.root("/", fileSystem)
+          val file = root / "test" / "dir" / "file.txt"
+          os.write(file, "Hello World")
+          os.list(root / "test").collect(os.copy.matching(mergeFolders = true) {
+            case p / "test" / _ => p
+          })
+          assert(os.read(root / "file.txt") == "Hello World")
+          assert(os.exists(root / "file.txt"))
+        }
+      }
+      test("moveMatchingToRootDirectory") {
+        withCustomFs { fileSystem =>
+          try {
+            os.list(os.root("/", fileSystem)).collect(os.move.matching { case p / "test" => p })
+          } catch {
+            case e: PathError.AbsolutePathOutsideRoot.type => throw e
+            case NonFatal(_) => ()
+          }
+        }
+      }
       test("remove") {
         withCustomFs { fileSystem =>
           val p = os.root("/", fileSystem) / "test" / "dir"

--- a/os/test/src-jvm/PathTestsCustomFilesystem.scala
+++ b/os/test/src-jvm/PathTestsCustomFilesystem.scala
@@ -206,11 +206,13 @@ object PathTestsCustomFilesystem extends TestSuite {
           assert(os.exists(root / "file.txt"))
         }
       }
-      test("moveMatchingToRootDirectoryShouldFail") {
+      test("moveMatchingToRootDirectory") {
         withCustomFs { fileSystem =>
-          // This should fail. Just test that it doesn't throw PathError.AbsolutePathOutsideRoot.
-          intercept[FileAlreadyExistsException] {
+          try {
             os.list(os.root("/", fileSystem)).collect(os.move.matching { case p / "test" => p })
+          } catch {
+            case e: PathError.AbsolutePathOutsideRoot.type => throw e
+            case NonFatal(_) => ()
           }
         }
       }

--- a/os/test/src-jvm/PathTestsCustomFilesystem.scala
+++ b/os/test/src-jvm/PathTestsCustomFilesystem.scala
@@ -2,11 +2,10 @@ package test.os
 
 import utest._
 import os._
+
 import java.util.HashMap
-import java.nio.file.FileSystems
+import java.nio.file.{FileAlreadyExistsException, FileSystem, FileSystems}
 import java.net.URI
-import java.nio.file.FileSystem
-import java.nio.file.Paths
 import scala.util.control.NonFatal
 
 object PathTestsCustomFilesystem extends TestSuite {
@@ -186,15 +185,12 @@ object PathTestsCustomFilesystem extends TestSuite {
           assert(os.exists(root / "file.txt"))
         }
       }
-      test("moveToRootDirectoryWithCreateFolders") {
+      test("moveToRootDirectoryWithCreateFoldersSouldFail") {
         withCustomFs { fileSystem =>
-          // This should fail. Just test that it doesn't throw PathError.AbsolutePathOutsideRoot.
           val root = os.root("/", fileSystem)
-          try {
+          // This should fail. Just test that it doesn't throw PathError.AbsolutePathOutsideRoot.
+          intercept[FileAlreadyExistsException] {
             os.move(root / "test" / "dir", root, createFolders = true)
-          } catch {
-            case e: PathError.AbsolutePathOutsideRoot.type => throw e
-            case NonFatal(_) => ()
           }
         }
       }


### PR DESCRIPTION
Fix an error where `os.copy(createFolders = true, mergeFolders = true)` a directory to root throw a `PathError.AbsolutePathOutsideRoot` due to calling `/up` on root.

The same issue (calling `/up` on root) is seen in `os.move`, `os.copy.matching` and `os.move.matching` so this fixes those as well. In case of `os.move` and `os.move.matching` moving a directory to root should throw an error anyway but at least now it throws the correct underlying error instead of `AbsolutePathOutsideRoot`.

Fix https://github.com/com-lihaoyi/os-lib/issues/167

Pull request: https://github.com/com-lihaoyi/os-lib/pull/267