### PR TITLE
Re-enable explicit TOC rendering in readme

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -1,5 +1,8 @@
 = OS-Lib
 :version: 0.10.1
+:toc-placement: preamble
+:toclevels: 3
+:toc:
 :link-geny: https://github.com/com-lihaoyi/geny
 :link-oslib: https://github.com/com-lihaoyi/os-lib
 :link-oslib-gitter: https://gitter.im/lihaoyi/os-lib


### PR DESCRIPTION
Looks like the links work again on GitHub.