### PR TITLE
Add API to redirect `os.Inherit`ed streams globally to be consistent with std streams redirections

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -2224,6 +2224,11 @@ string, int or set representations of the `os.PermSet` via:
 
 == Changelog
 
+[#0-10-3]
+=== 0.10.3
+
+* `os.Inherit`
+
 [#0-10-2]
 === 0.10.2
 

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -2224,8 +2224,8 @@ string, int or set representations of the `os.PermSet` via:
 
 == Changelog
 
-[#0-10-3]
-=== 0.10.3
+[#main]
+=== main
 
 * `os.Inherit`
 

--- a/os/src/ProcessOps.scala
+++ b/os/src/ProcessOps.scala
@@ -119,6 +119,18 @@ case class proc(command: Shellable*) {
 
     val cmdChunks = commandChunks
     val commandStr = cmdChunks.mkString(" ")
+    val resolvedStdin = stdin match {
+      case os.Inherit => os.Inherit.in
+      case v => v
+    }
+    val resolvedStdout = stdout match {
+      case os.Inherit => os.Inherit.out
+      case v => v
+    }
+    val resolvedStderr = stderr match {
+      case os.Inherit => os.Inherit.err
+      case v => v
+    }
     lazy val proc: SubProcess = new SubProcess(
       builder.start(),
       stdin.processInput(proc.stdin).map(new Thread(_, commandStr + " stdin thread")),

--- a/os/src/ProcessOps.scala
+++ b/os/src/ProcessOps.scala
@@ -114,28 +114,31 @@ case class proc(command: Shellable*) {
       mergeErrIntoOut: Boolean = false,
       propagateEnv: Boolean = true
   ): SubProcess = {
-    val builder =
-      buildProcess(commandChunks, cwd, env, stdin, stdout, stderr, mergeErrIntoOut, propagateEnv)
 
     val cmdChunks = commandChunks
     val commandStr = cmdChunks.mkString(" ")
-    val resolvedStdin = stdin match {
-      case os.Inherit => os.Inherit.in
-      case v => v
-    }
-    val resolvedStdout = stdout match {
-      case os.Inherit => os.Inherit.out
-      case v => v
-    }
-    val resolvedStderr = stderr match {
-      case os.Inherit => os.Inherit.err
-      case v => v
-    }
+
+    def resolve[T](x: T, y: T) = if (x == os.Inherit) y else x
+    val resolvedStdin = resolve(stdin, os.Inherit.in.value)
+    val resolvedStdout = resolve(stdout, os.Inherit.out.value)
+    val resolvedStderr =  resolve(stderr, os.Inherit.err.value)
+
+    val builder = buildProcess(
+      commandChunks,
+      cwd,
+      env,
+      resolvedStdin,
+      resolvedStdout,
+      resolvedStderr,
+      mergeErrIntoOut,
+      propagateEnv
+    )
+
     lazy val proc: SubProcess = new SubProcess(
       builder.start(),
-      stdin.processInput(proc.stdin).map(new Thread(_, commandStr + " stdin thread")),
-      stdout.processOutput(proc.stdout).map(new Thread(_, commandStr + " stdout thread")),
-      stderr.processOutput(proc.stderr).map(new Thread(_, commandStr + " stderr thread"))
+      resolvedStdin.processInput(proc.stdin).map(new Thread(_, commandStr + " stdin thread")),
+      resolvedStdout.processOutput(proc.stdout).map(new Thread(_, commandStr + " stdout thread")),
+      resolvedStderr.processOutput(proc.stderr).map(new Thread(_, commandStr + " stderr thread"))
     )
 
     proc.inputPumperThread.foreach(_.start())

--- a/os/src/ProcessOps.scala
+++ b/os/src/ProcessOps.scala
@@ -121,7 +121,7 @@ case class proc(command: Shellable*) {
     def resolve[T](x: T, y: T) = if (x == os.Inherit) y else x
     val resolvedStdin = resolve(stdin, os.Inherit.in.value)
     val resolvedStdout = resolve(stdout, os.Inherit.out.value)
-    val resolvedStderr =  resolve(stderr, os.Inherit.err.value)
+    val resolvedStderr = resolve(stderr, os.Inherit.err.value)
 
     val builder = buildProcess(
       commandChunks,

--- a/os/src/SubProcess.scala
+++ b/os/src/SubProcess.scala
@@ -460,7 +460,7 @@ object Inherit extends ProcessInput with ProcessOutput {
  * Inherit the input/output stream from the current process.
  * Identical of [[os.Inherit]], except it cannot be redirected globally
  */
-object Inherit0 extends ProcessInput with ProcessOutput {
+object InheritRaw extends ProcessInput with ProcessOutput {
   def redirectTo = ProcessBuilder.Redirect.INHERIT
   def redirectFrom = ProcessBuilder.Redirect.INHERIT
   def processInput(stdin: => SubProcess.InputStream) = None

--- a/os/src/SubProcess.scala
+++ b/os/src/SubProcess.scala
@@ -467,7 +467,6 @@ object Inherit0 extends ProcessInput with ProcessOutput {
   def processOutput(stdin: => SubProcess.OutputStream) = None
 }
 
-
 /**
  * Pipe the input/output stream to the current process to be used via
  * `java.lang.Process#{getInputStream,getOutputStream,getErrorStream}`

--- a/os/src/SubProcess.scala
+++ b/os/src/SubProcess.scala
@@ -440,14 +440,33 @@ object ProcessOutput {
 }
 
 /**
- * Inherit the input/output stream from the current process
+ * Inherit the input/output stream from the current process.
+ *
+ * Can be overriden on a thread local basis for the various
+ * kinds of streams (stdin, stdout, stderr) via [[in]], [[out]], and [[err]]
  */
 object Inherit extends ProcessInput with ProcessOutput {
   def redirectTo = ProcessBuilder.Redirect.INHERIT
   def redirectFrom = ProcessBuilder.Redirect.INHERIT
   def processInput(stdin: => SubProcess.InputStream) = None
   def processOutput(stdin: => SubProcess.OutputStream) = None
+
+  val in = new scala.util.DynamicVariable[ProcessInput](Inherit)
+  val out = new scala.util.DynamicVariable[ProcessOutput](Inherit)
+  val err = new scala.util.DynamicVariable[ProcessOutput](Inherit)
 }
+
+/**
+ * Inherit the input/output stream from the current process.
+ * Identical of [[os.Inherit]], except it cannot be redirected globally
+ */
+object Inherit0 extends ProcessInput with ProcessOutput {
+  def redirectTo = ProcessBuilder.Redirect.INHERIT
+  def redirectFrom = ProcessBuilder.Redirect.INHERIT
+  def processInput(stdin: => SubProcess.InputStream) = None
+  def processOutput(stdin: => SubProcess.OutputStream) = None
+}
+
 
 /**
  * Pipe the input/output stream to the current process to be used via

--- a/os/test/src-jvm/OpTestsJvmOnly.scala
+++ b/os/test/src-jvm/OpTestsJvmOnly.scala
@@ -70,5 +70,14 @@ object OpTestsJvmOnly extends TestSuite {
       val d = testFolder / "readWrite"
       intercept[nio.NoSuchFileException](os.list(d / "nonexistent"))
     }
+
+    // Not sure why this doesn't work on native
+    test("redirectSubprocessInheritedOutput") {
+      val lines = collection.mutable.Buffer.empty[String]
+      os.Inherit.out.withValue(os.ProcessOutput.Readlines(lines.append(_))) {
+        proc(scriptFolder / "misc" / "echo_with_wd", "HELLO\nWorld").call(cwd = root / "usr", stdout = os.Inherit)
+      }
+      assert(lines == Seq("HELLO", "World /usr"))
+    }
   }
 }

--- a/os/test/src-jvm/OpTestsJvmOnly.scala
+++ b/os/test/src-jvm/OpTestsJvmOnly.scala
@@ -73,9 +73,10 @@ object OpTestsJvmOnly extends TestSuite {
 
     // Not sure why this doesn't work on native
     test("redirectSubprocessInheritedOutput") {
+      val scriptFolder = os.pwd / "os" / "test" / "resources" / "test"
       val lines = collection.mutable.Buffer.empty[String]
       os.Inherit.out.withValue(os.ProcessOutput.Readlines(lines.append(_))) {
-        proc(scriptFolder / "misc" / "echo_with_wd", "HELLO\nWorld").call(cwd = root / "usr", stdout = os.Inherit)
+        os.proc(scriptFolder / "misc" / "echo_with_wd", "HELLO\nWorld").call(cwd = root / "usr", stdout = os.Inherit)
       }
       assert(lines == Seq("HELLO", "World /usr"))
     }

--- a/os/test/src-jvm/OpTestsJvmOnly.scala
+++ b/os/test/src-jvm/OpTestsJvmOnly.scala
@@ -77,9 +77,15 @@ object OpTestsJvmOnly extends TestSuite {
         val scriptFolder = os.pwd / "os" / "test" / "resources" / "test"
         val lines = collection.mutable.Buffer.empty[String]
         os.Inherit.out.withValue(os.ProcessOutput.Readlines(lines.append(_))) {
+          // Redirected
           os.proc(scriptFolder / "misc" / "echo_with_wd", "HELLO\nWorld").call(
             cwd = os.root / "usr",
             stdout = os.Inherit
+          )
+          // Not Redirected
+          os.proc(scriptFolder / "misc" / "echo_with_wd", "hello\nWORLD").call(
+            cwd = os.root / "usr",
+            stdout = os.InheritRaw
           )
         }
         assert(lines == Seq("HELLO", "World /usr"))

--- a/os/test/src-jvm/OpTestsJvmOnly.scala
+++ b/os/test/src-jvm/OpTestsJvmOnly.scala
@@ -73,15 +73,17 @@ object OpTestsJvmOnly extends TestSuite {
 
     // Not sure why this doesn't work on native
     test("redirectSubprocessInheritedOutput") {
-      val scriptFolder = os.pwd / "os" / "test" / "resources" / "test"
-      val lines = collection.mutable.Buffer.empty[String]
-      os.Inherit.out.withValue(os.ProcessOutput.Readlines(lines.append(_))) {
-        os.proc(scriptFolder / "misc" / "echo_with_wd", "HELLO\nWorld").call(
-          cwd = os.root / "usr",
-          stdout = os.Inherit
-        )
+      if (Unix()) { // relies on bash scripts that don't run on windows
+        val scriptFolder = os.pwd / "os" / "test" / "resources" / "test"
+        val lines = collection.mutable.Buffer.empty[String]
+        os.Inherit.out.withValue(os.ProcessOutput.Readlines(lines.append(_))) {
+          os.proc(scriptFolder / "misc" / "echo_with_wd", "HELLO\nWorld").call(
+            cwd = os.root / "usr",
+            stdout = os.Inherit
+          )
+        }
+        assert(lines == Seq("HELLO", "World /usr"))
       }
-      assert(lines == Seq("HELLO", "World /usr"))
     }
   }
 }

--- a/os/test/src-jvm/OpTestsJvmOnly.scala
+++ b/os/test/src-jvm/OpTestsJvmOnly.scala
@@ -76,7 +76,10 @@ object OpTestsJvmOnly extends TestSuite {
       val scriptFolder = os.pwd / "os" / "test" / "resources" / "test"
       val lines = collection.mutable.Buffer.empty[String]
       os.Inherit.out.withValue(os.ProcessOutput.Readlines(lines.append(_))) {
-        os.proc(scriptFolder / "misc" / "echo_with_wd", "HELLO\nWorld").call(cwd = root / "usr", stdout = os.Inherit)
+        os.proc(scriptFolder / "misc" / "echo_with_wd", "HELLO\nWorld").call(
+          cwd = os.root / "usr",
+          stdout = os.Inherit
+        )
       }
       assert(lines == Seq("HELLO", "World /usr"))
     }

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -203,12 +203,5 @@ object SubprocessTests extends TestSuite {
         assert(output.out.lines() == Seq("HELLO /usr"))
       }
     }
-    test("redirectSubprocessInheritedOutput") {
-      val lines = collection.mutable.Buffer.empty[String]
-      os.Inherit.out.withValue(os.ProcessOutput.Readlines(lines.append)){
-        proc(scriptFolder / "misc" / "echo_with_wd", "HELLO\nWorld").call(cwd = root / "usr", stdout = os.Inherit)
-      }
-      assert(lines == Seq("HELLO", "World /usr"))
-    }
   }
 }

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -203,5 +203,12 @@ object SubprocessTests extends TestSuite {
         assert(output.out.lines() == Seq("HELLO /usr"))
       }
     }
+    test("redirectSubprocessInheritedOutput") {
+      val lines = collection.mutable.Buffer.empty[String]
+      os.Inherit.out.withValue(os.ProcessOutput.Readlines(lines.append)){
+        proc(scriptFolder / "misc" / "echo_with_wd", "HELLO\nWorld").call(cwd = root / "usr", stdout = os.Inherit)
+      }
+      assert(lines == Seq("HELLO", "World /usr"))
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/os-lib/issues/282

Unlike usage of `System.in`/`System.out`/`System.err` programmatically, or the `scala.Console` equivalents, output from subprocesses with `os.Inherit` is not affected by `System.setIn`/`setOut`/`setErr`. This is often counterintuitive, because you expect redirecting these streams to redirect all output, only to find output from subprocess leaking through a side channel to the original process `in`/`out`/`err`.

This PR adds the `os.Inherit.in`/`out`/`err` dynamic variables, which can be used to re-assign `os.Inherit` on a scoped threadlocal basis. This allows developers who use `System.setOut` or `Console.withOut` to also redirect subprocess output within the scope of the stdout redirect, without users working within those scopes to have to remember to redirect them manually at every callsite.

Because we do not control `System.setOut` or `Console.withOut`, there isn't really a way for us to detect and do this automatically (e.g. redirects may happen even before OS-Lib has been even classloaded) and so we have to rely on it being opt-in.

As an escape hatch, in case users do not want this behavior, we provide a `os.Inherit0` redirect which performs identically to the original `os.Inherit` even in the process of redirecting `os.Inherit.{in,out,err}`

Covered by an added unit test