### PR TITLE
Introduce `os.SubProcess.env` `DynamicVariable` to override default `env`

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -1676,7 +1676,7 @@ It is possible to customize the default environment passed to subprocesses by se
 ----
 val clientEnvironment: Map[String, String] = ???
 os.SubProcess.env.withValue(clientEnvironment) {
-  os.proc(command).call() // clientEnvironment is passed by default instead of the system environment
+  os.call(command) // clientEnvironment is passed by default instead of the system environment
 }
 ----
 

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -1667,6 +1667,19 @@ val sha = os.spawn(cmd = ("shasum", "-a", "256"), stdin = gzip.stdout)
 sha.stdout.trim ==> "acc142175fa520a1cb2be5b97cbbe9bea092e8bba3fe2e95afa645615908229e  -"
 ----
 
+==== Customizing the default environment
+
+Client-server CLI applications sometimes want to run subprocesses on the server based on the environment of the client.
+It is possible to customize the default environment passed to subprocesses by setting the `os.SubProcess.env` threadlocal:
+
+[source,scala]
+----
+val clientEnvironment: Map[String, String] = ???
+os.SubProcess.env.withValue(clientEnvironment) {
+  os.proc(command).call() // clientEnvironment is passed by default instead of the system environment
+}
+----
+
 == Spawning Pipelines of Subprocesses
 
 After constructing a subprocess with `os.proc`, you can use the `pipeTo` method

--- a/build.sc
+++ b/build.sc
@@ -51,7 +51,8 @@ trait SafeDeps extends ScalaModule {
 }
 
 trait MiMaChecks extends Mima {
-  def mimaPreviousVersions = Seq("0.9.0", "0.9.1", "0.9.2", "0.9.3", "0.10.0", "0.10.1", "0.10.2", "0.10.3", "0.10.4")
+  def mimaPreviousVersions =
+    Seq("0.9.0", "0.9.1", "0.9.2", "0.9.3", "0.10.0", "0.10.1", "0.10.2", "0.10.3", "0.10.4")
   override def mimaBinaryIssueFilters: T[Seq[ProblemFilter]] = Seq(
     ProblemFilter.exclude[ReversedMissingMethodProblem]("os.PathConvertible.isCustomFs"),
     // this is fine, because ProcessLike is sealed (and its subclasses should be final)

--- a/build.sc
+++ b/build.sc
@@ -55,8 +55,7 @@ trait MiMaChecks extends Mima {
   override def mimaBinaryIssueFilters: T[Seq[ProblemFilter]] = Seq(
     ProblemFilter.exclude[ReversedMissingMethodProblem]("os.PathConvertible.isCustomFs"),
     // this is fine, because ProcessLike is sealed (and its subclasses should be final)
-    ProblemFilter.exclude[ReversedMissingMethodProblem]("os.ProcessLike.joinPumperThreadsHook"),
-    ProblemFilter.exclude[MissingTypesProblem]("os.proc$")
+    ProblemFilter.exclude[ReversedMissingMethodProblem]("os.ProcessLike.joinPumperThreadsHook")
   )
 }
 

--- a/build.sc
+++ b/build.sc
@@ -51,11 +51,12 @@ trait SafeDeps extends ScalaModule {
 }
 
 trait MiMaChecks extends Mima {
-  def mimaPreviousVersions = Seq("0.9.0", "0.9.1", "0.9.2", "0.9.3", "0.10.0")
+  def mimaPreviousVersions = Seq("0.9.0", "0.9.1", "0.9.2", "0.9.3", "0.10.0", "0.10.1", "0.10.2", "0.10.3", "0.10.4")
   override def mimaBinaryIssueFilters: T[Seq[ProblemFilter]] = Seq(
     ProblemFilter.exclude[ReversedMissingMethodProblem]("os.PathConvertible.isCustomFs"),
     // this is fine, because ProcessLike is sealed (and its subclasses should be final)
-    ProblemFilter.exclude[ReversedMissingMethodProblem]("os.ProcessLike.joinPumperThreadsHook")
+    ProblemFilter.exclude[ReversedMissingMethodProblem]("os.ProcessLike.joinPumperThreadsHook"),
+    ProblemFilter.exclude[MissingTypesProblem]("os.proc$")
   )
 }
 

--- a/os/src/ProcessOps.scala
+++ b/os/src/ProcessOps.scala
@@ -251,19 +251,6 @@ case class proc(command: Shellable*) {
   def pipeTo(next: proc): ProcGroup = ProcGroup(Seq(this, next))
 }
 
-object proc {
-
-  /**
-   * The env passed by default to child processes
-   */
-  val env = new scala.util.DynamicVariable[Map[String, String]](sys.env)
-
-  // TODO: Delete when in binary compatibity breaking window
-  def andThen[T](f: proc => T): Seq[Shellable] => T = s => f(apply(s))
-  // TODO: Delete when in binary compatibity breaking window
-  def compose[T](f: T => Seq[Shellable]): T => proc = t => apply(f(t))
-}
-
 /**
  * A group of processes that are piped together, corresponding to e.g. `ls -l | grep .scala`.
  * You can create a `ProcGroup` by calling `.pipeTo` on a [[proc]] multiple times.
@@ -509,7 +496,7 @@ private[os] object ProcessOps {
       }
 
     if (propagateEnv) {
-      addToProcessEnv(os.proc.env.value)
+      addToProcessEnv(os.SubProcess.env.value)
     }
 
     addToProcessEnv(env)

--- a/os/src/ProcessOps.scala
+++ b/os/src/ProcessOps.scala
@@ -252,7 +252,16 @@ case class proc(command: Shellable*) {
 }
 
 object proc {
+
+  /**
+   * The env passed by default to child processes
+   */
   val env = new scala.util.DynamicVariable[Map[String, String]](sys.env)
+
+  // TODO: Delete when in binary compatibity breaking window
+  def andThen[T](f: proc => T): Seq[Shellable] => T = s => f(apply(s))
+  // TODO: Delete when in binary compatibity breaking window
+  def compose[T](f: T => Seq[Shellable]): T => proc = t => apply(f(t))
 }
 
 /**

--- a/os/src/ProcessOps.scala
+++ b/os/src/ProcessOps.scala
@@ -485,18 +485,25 @@ private[os] object ProcessOps {
     val builder = new java.lang.ProcessBuilder()
 
     val environment = builder.environment()
-    environment.clear()
 
     def addToProcessEnv(env: Map[String, String]) =
       if (env != null) {
         for ((k, v) <- env) {
-          if (v != null) builder.environment().put(k, v)
-          else builder.environment().remove(k)
+          if (v != null) environment.put(k, v)
+          else environment.remove(k)
         }
       }
 
-    if (propagateEnv) {
-      addToProcessEnv(os.SubProcess.env.value)
+    os.SubProcess.env.value match {
+      case null =>
+        if (!propagateEnv) {
+          environment.clear()
+        }
+      case subProcessEnvValue =>
+        environment.clear()
+        if (propagateEnv) {
+          addToProcessEnv(subProcessEnvValue)
+        }
     }
 
     addToProcessEnv(env)

--- a/os/src/SubProcess.scala
+++ b/os/src/SubProcess.scala
@@ -163,9 +163,10 @@ class SubProcess(
 object SubProcess {
 
   /**
-   * The env passed by default to child processes
+   * The env passed by default to child processes.
+   * When `null`, the system environment is used.
    */
-  val env = new scala.util.DynamicVariable[Map[String, String]](sys.env)
+  val env = new scala.util.DynamicVariable[Map[String, String]](null)
 
   /**
    * A [[BufferedWriter]] with the underlying [[java.io.OutputStream]] exposed

--- a/os/src/SubProcess.scala
+++ b/os/src/SubProcess.scala
@@ -163,6 +163,11 @@ class SubProcess(
 object SubProcess {
 
   /**
+   * The env passed by default to child processes
+   */
+  val env = new scala.util.DynamicVariable[Map[String, String]](sys.env)
+
+  /**
    * A [[BufferedWriter]] with the underlying [[java.io.OutputStream]] exposed
    *
    * Note that all writes that occur through this class are thread-safe and

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -146,6 +146,22 @@ object SubprocessTests extends TestSuite {
         }
       }
     }
+    test("envWithValue") {
+      if (Unix()) {
+        def envValue() = os.proc("bash", "-c", "echo \"$TEST_ENV_FOO\"").call().out.lines().head
+        
+        val before = envValue()
+        assert(before == "")
+        
+        os.proc.env.withValue(Map("TEST_ENV_FOO" -> "bar")) {
+          val res = envValue()
+          assert(res == "bar")
+        }
+
+        val after = envValue()
+        assert(after == "")
+      }
+    }
     test("multiChunk") {
       // Make sure that in the case where multiple chunks are being read from
       // the subprocess in quick succession, we ensure that the output handler

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -153,7 +153,7 @@ object SubprocessTests extends TestSuite {
         def envValue() = os.proc(
           "bash",
           "-c",
-          s"if [ -z $${$variableName+x} ]; then echo \"unset\"; else echo \"$$$variableName\"; fi"
+          s"""if [ -z $${$variableName+x} ]; then echo "unset"; else echo "$$$variableName"; fi"""
         ).call().out.lines().head
 
         val before = envValue()

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -148,18 +148,20 @@ object SubprocessTests extends TestSuite {
     }
     test("envWithValue") {
       if (Unix()) {
-        def envValue() = os.proc("bash", "-c", "echo \"$TEST_ENV_FOO\"").call().out.lines().head
+        val variableName = "TEST_ENV_FOO"
+        val variableValue = "bar"
+        def envValue() = os.proc("bash", "-c", s"if [ -z $${$variableName+x} ]; then echo \"unset\"; else echo \"$$$variableName\"; fi").call().out.lines().head
 
         val before = envValue()
-        assert(before == "")
+        assert(before == "unset")
 
-        os.SubProcess.env.withValue(Map("TEST_ENV_FOO" -> "bar")) {
+        os.SubProcess.env.withValue(Map(variableName -> variableValue)) {
           val res = envValue()
-          assert(res == "bar")
+          assert(res == variableValue)
         }
 
         val after = envValue()
-        assert(after == "")
+        assert(after == "unset")
       }
     }
     test("multiChunk") {

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -149,10 +149,10 @@ object SubprocessTests extends TestSuite {
     test("envWithValue") {
       if (Unix()) {
         def envValue() = os.proc("bash", "-c", "echo \"$TEST_ENV_FOO\"").call().out.lines().head
-        
+
         val before = envValue()
         assert(before == "")
-        
+
         os.proc.env.withValue(Map("TEST_ENV_FOO" -> "bar")) {
           val res = envValue()
           assert(res == "bar")

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -150,7 +150,11 @@ object SubprocessTests extends TestSuite {
       if (Unix()) {
         val variableName = "TEST_ENV_FOO"
         val variableValue = "bar"
-        def envValue() = os.proc("bash", "-c", s"if [ -z $${$variableName+x} ]; then echo \"unset\"; else echo \"$$$variableName\"; fi").call().out.lines().head
+        def envValue() = os.proc(
+          "bash",
+          "-c",
+          s"if [ -z $${$variableName+x} ]; then echo \"unset\"; else echo \"$$$variableName\"; fi"
+        ).call().out.lines().head
 
         val before = envValue()
         assert(before == "unset")

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -153,7 +153,7 @@ object SubprocessTests extends TestSuite {
         val before = envValue()
         assert(before == "")
 
-        os.proc.env.withValue(Map("TEST_ENV_FOO" -> "bar")) {
+        os.SubProcess.env.withValue(Map("TEST_ENV_FOO" -> "bar")) {
           val res = envValue()
           assert(res == "bar")
         }


### PR DESCRIPTION
In Mill and any client-server application, it is handy to start processes on the server passing the client environment. This requires to pass the environment manually in all the `os.proc(...).call()`s. An easier alternative is to override the environment as we to for `os.Inherit` `out`, `in` and `err` pipes. So users can forget about the environment and have the right one passed automatically.

Pull request: https://github.com/com-lihaoyi/os-lib/pull/295