### PR TITLE
Allow multiple segments in Stringliterals

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -24,6 +24,7 @@ object Deps {
   val geny = ivy"com.lihaoyi::geny::1.1.1"
   val sourcecode = ivy"com.lihaoyi::sourcecode::0.4.2"
   val utest = ivy"com.lihaoyi::utest::0.8.4"
+  def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:$scalaVersion"
   def scalaLibrary(version: String) = ivy"org.scala-lang:scala-library:${version}"
 }
 
@@ -94,6 +95,13 @@ trait OsLibModule
 
 trait OsModule extends OsLibModule { outer =>
   def ivyDeps = Agg(Deps.geny)
+  override def compileIvyDeps = T{
+    scalaVersion.zip(super.compileIvyDeps).map{
+      case (scalaVer,superDeps) =>
+        val scalaReflectOpt = if (!ZincWorkerUtil.isDottyOrScala3(scalaVer)) Some(Deps.scalaReflect(scalaVer)) else None
+        superDeps ++ Agg.from(scalaReflectOpt)
+    }
+  }
 
   def artifactName = "os-lib"
 

--- a/build.sc
+++ b/build.sc
@@ -96,11 +96,10 @@ trait OsLibModule
 trait OsModule extends OsLibModule { outer =>
   def ivyDeps = Agg(Deps.geny)
   override def compileIvyDeps = T{
-    scalaVersion.zip(super.compileIvyDeps).map{
-      case (scalaVer,superDeps) =>
-        val scalaReflectOpt = if (!ZincWorkerUtil.isDottyOrScala3(scalaVer)) Some(Deps.scalaReflect(scalaVer)) else None
-        superDeps ++ Agg.from(scalaReflectOpt)
-    }
+    val scalaReflectOpt = Option.when(!ZincWorkerUtil.isDottyOrScala3(scalaVersion())) (
+      Deps.scalaReflect(scalaVersion())
+    )
+    super.compileIvyDeps() ++ scalaReflectOpt
   }
 
   def artifactName = "os-lib"

--- a/os/src-2/Macros.scala
+++ b/os/src-2/Macros.scala
@@ -6,13 +6,15 @@ import os.PathChunk.{SubPathChunk, segmentsFromString}
 import scala.language.experimental.macros
 import acyclic.skipped
 
-trait PathChunkMacros extends ViewBoundImplicit {
-  implicit def validatedStringChunk(s: String): PathChunk = macro Macros.validatedStringChunkImpl
+// StringPathChunkConversion is a fallback to non-macro String => PathChunk implicit conversion in case eta expansion is needed, this is required for ArrayPathChunk and SeqPathChunk
+trait PathChunkMacros extends StringPathChunkConversion {
+  implicit def stringPathChunkValidated(s: String): PathChunk =
+    macro Macros.stringPathChunkValidatedImpl
 }
 
 object Macros {
 
-  def validatedStringChunkImpl(c: blackbox.Context)(s: c.Expr[String]): c.Expr[SubPathChunk] = {
+  def stringPathChunkValidatedImpl(c: blackbox.Context)(s: c.Expr[String]): c.Expr[SubPathChunk] = {
     import c.universe._
 
     s match {

--- a/os/src-2/Macros.scala
+++ b/os/src-2/Macros.scala
@@ -1,0 +1,27 @@
+package os
+
+import scala.reflect.macros.blackbox
+import os.PathChunk.SubPathChunk
+import scala.language.experimental.macros
+import acyclic.skipped
+
+trait PathChunkMacros extends ViewBoundImplicit{
+  implicit def validatedStringChunk(s: String): PathChunk = macro Macros.validatedStringChunkImpl
+}
+
+object Macros {
+
+  def validatedStringChunkImpl(c: blackbox.Context)(s: c.Expr[String]): c.Expr[SubPathChunk] = {
+    import c.universe._
+
+    s match {
+      case Expr(Literal(Constant(literal: String))) =>
+        val splitted = literal.splitWithDelimiters("/",-1).filterNot(_ == "/")
+        splitted.foreach(BasePath.checkSegment)
+
+        c.Expr(q"new _root_.os.PathChunk.SubPathChunk(_root_.os.SubPath.apply(${splitted}.toIndexedSeq))")
+      case nonLiteral =>
+        c.Expr(q"new _root_.os.PathChunk.SubPathChunk(_root_.os.SubPath.apply(IndexedSeq($nonLiteral)))")
+    }
+  }
+}

--- a/os/src-2/Macros.scala
+++ b/os/src-2/Macros.scala
@@ -5,7 +5,7 @@ import os.PathChunk.SubPathChunk
 import scala.language.experimental.macros
 import acyclic.skipped
 
-trait PathChunkMacros extends ViewBoundImplicit{
+trait PathChunkMacros extends ViewBoundImplicit {
   implicit def validatedStringChunk(s: String): PathChunk = macro Macros.validatedStringChunkImpl
 }
 
@@ -16,12 +16,16 @@ object Macros {
 
     s match {
       case Expr(Literal(Constant(literal: String))) =>
-        val splitted = literal.splitWithDelimiters("/",-1).filterNot(_ == "/")
+        val splitted = literal.splitWithDelimiters("/", -1).filterNot(_ == "/")
         splitted.foreach(BasePath.checkSegment)
 
-        c.Expr(q"new _root_.os.PathChunk.SubPathChunk(_root_.os.SubPath.apply(${splitted}.toIndexedSeq))")
+        c.Expr(
+          q"new _root_.os.PathChunk.SubPathChunk(_root_.os.SubPath.apply(${splitted}.toIndexedSeq))"
+        )
       case nonLiteral =>
-        c.Expr(q"new _root_.os.PathChunk.SubPathChunk(_root_.os.SubPath.apply(IndexedSeq($nonLiteral)))")
+        c.Expr(
+          q"new _root_.os.PathChunk.SubPathChunk(_root_.os.SubPath.apply(IndexedSeq($nonLiteral)))"
+        )
     }
   }
 }

--- a/os/src-2/Macros.scala
+++ b/os/src-2/Macros.scala
@@ -1,7 +1,8 @@
 package os
 
 import scala.reflect.macros.blackbox
-import os.PathChunk.SubPathChunk
+import os.PathChunk.{SubPathChunk, segmentsFromString}
+
 import scala.language.experimental.macros
 import acyclic.skipped
 
@@ -16,11 +17,11 @@ object Macros {
 
     s match {
       case Expr(Literal(Constant(literal: String))) =>
-        val splitted = literal.splitWithDelimiters("/", -1).filterNot(_ == "/")
-        splitted.foreach(BasePath.checkSegment)
+        val stringSegments = segmentsFromString(literal)
+        stringSegments.foreach(BasePath.checkSegment)
 
         c.Expr(
-          q"new _root_.os.PathChunk.SubPathChunk(_root_.os.SubPath.apply(${splitted}.toIndexedSeq))"
+          q"new _root_.os.PathChunk.SubPathChunk(_root_.os.SubPath.apply(${stringSegments}.toIndexedSeq))"
         )
       case nonLiteral =>
         c.Expr(

--- a/os/src-2/Macros.scala
+++ b/os/src-2/Macros.scala
@@ -1,7 +1,7 @@
 package os
 
 import scala.reflect.macros.blackbox
-import os.PathChunk.{SubPathChunk, segmentsFromString}
+import os.PathChunk.segmentsFromString
 
 import scala.language.experimental.macros
 import acyclic.skipped
@@ -14,7 +14,7 @@ trait PathChunkMacros extends StringPathChunkConversion {
 
 object Macros {
 
-  def stringPathChunkValidatedImpl(c: blackbox.Context)(s: c.Expr[String]): c.Expr[SubPathChunk] = {
+  def stringPathChunkValidatedImpl(c: blackbox.Context)(s: c.Expr[String]): c.Expr[PathChunk] = {
     import c.universe._
 
     s match {
@@ -23,11 +23,11 @@ object Macros {
         stringSegments.foreach(BasePath.checkSegment)
 
         c.Expr(
-          q"new _root_.os.PathChunk.SubPathChunk(_root_.os.SubPath.apply(${stringSegments}.toIndexedSeq))"
+          q"new _root_.os.PathChunk.ArrayPathChunk[String]($stringSegments)(_root_.os.PathChunk.stringToPathChunk)"
         )
       case nonLiteral =>
         c.Expr(
-          q"new _root_.os.PathChunk.SubPathChunk(_root_.os.SubPath.apply(IndexedSeq($nonLiteral)))"
+          q"new _root_.os.PathChunk.StringPathChunk($nonLiteral)"
         )
     }
   }

--- a/os/src-3/Macros.scala
+++ b/os/src-3/Macros.scala
@@ -1,7 +1,7 @@
 package os
 
 import os.Macros.validatedPathChunkImpl
-import os.PathChunk.SubPathChunk
+import os.PathChunk.{SubPathChunk, segmentsFromString}
 
 import scala.collection.immutable.IndexedSeq
 import scala.quoted.{Expr, Quotes}
@@ -16,10 +16,10 @@ object Macros {
 
     s.asTerm match {
       case Inlined(_, _, Literal(StringConstant(literal))) =>
-        val splitted = literal.splitWithDelimiters("/",-1).filterNot(_ == "/")
-        splitted.foreach(BasePath.checkSegment)
+        val stringSegments = segmentsFromString(literal)
+        stringSegments.foreach(BasePath.checkSegment)
 
-        '{new SubPathChunk(SubPath.apply(${Expr(splitted)}.toIndexedSeq))}
+        '{new SubPathChunk(SubPath.apply(${Expr(stringSegments)}.toIndexedSeq))}
       case _ =>
         '{{new SubPathChunk(SubPath.apply(IndexedSeq($s)))}}
     }

--- a/os/src-3/Macros.scala
+++ b/os/src-3/Macros.scala
@@ -1,6 +1,6 @@
 package os
 
-import os.PathChunk.{SubPathChunk, segmentsFromString}
+import os.PathChunk.{ArrayPathChunk, StringPathChunk, segmentsFromString, stringToPathChunk}
 
 import scala.quoted.{Expr, Quotes}
 
@@ -11,7 +11,7 @@ trait PathChunkMacros extends StringPathChunkConversion {
 }
 
 object Macros {
-  def stringPathChunkValidatedImpl(s: Expr[String])(using quotes: Quotes): Expr[SubPathChunk] = {
+  def stringPathChunkValidatedImpl(s: Expr[String])(using quotes: Quotes): Expr[PathChunk] = {
     import quotes.reflect.*
 
     s.asTerm match {
@@ -19,9 +19,9 @@ object Macros {
         val stringSegments = segmentsFromString(literal)
         stringSegments.foreach(BasePath.checkSegment)
 
-        '{ new SubPathChunk(SubPath.apply(${ Expr(stringSegments) }.toIndexedSeq)) }
+        '{ new ArrayPathChunk[String](${ Expr(stringSegments) })(using stringToPathChunk) }
       case _ =>
-        '{ { new SubPathChunk(SubPath.apply(IndexedSeq($s))) } }
+        '{ { new StringPathChunk($s) } }
     }
   }
 }

--- a/os/src-3/Macros.scala
+++ b/os/src-3/Macros.scala
@@ -1,18 +1,17 @@
 package os
 
-import os.Macros.validatedPathChunkImpl
 import os.PathChunk.{SubPathChunk, segmentsFromString}
 
-import scala.collection.immutable.IndexedSeq
 import scala.quoted.{Expr, Quotes}
 
 // StringPathChunkConversion is a fallback to non-macro String => PathChunk implicit conversion in case eta expansion is needed, this is required for ArrayPathChunk and SeqPathChunk
-trait PathChunkMacros extends StringPathChunkConversion{
-  inline implicit def stringPathChunkValidated(s:String): PathChunk = ${stringPathChunkValidatedImpl('s)}
+trait PathChunkMacros extends StringPathChunkConversion {
+  inline implicit def stringPathChunkValidated(s: String): PathChunk =
+    ${ Macros.stringPathChunkValidatedImpl('s) }
 }
 
 object Macros {
-  def stringPathChunkValidatedImpl(s:Expr[String])(using quotes: Quotes): Expr[SubPathChunk] = {
+  def stringPathChunkValidatedImpl(s: Expr[String])(using quotes: Quotes): Expr[SubPathChunk] = {
     import quotes.reflect.*
 
     s.asTerm match {
@@ -20,9 +19,9 @@ object Macros {
         val stringSegments = segmentsFromString(literal)
         stringSegments.foreach(BasePath.checkSegment)
 
-        '{new SubPathChunk(SubPath.apply(${Expr(stringSegments)}.toIndexedSeq))}
+        '{ new SubPathChunk(SubPath.apply(${ Expr(stringSegments) }.toIndexedSeq)) }
       case _ =>
-        '{{new SubPathChunk(SubPath.apply(IndexedSeq($s)))}}
+        '{ { new SubPathChunk(SubPath.apply(IndexedSeq($s))) } }
     }
   }
 }

--- a/os/src-3/Macros.scala
+++ b/os/src-3/Macros.scala
@@ -6,12 +6,13 @@ import os.PathChunk.{SubPathChunk, segmentsFromString}
 import scala.collection.immutable.IndexedSeq
 import scala.quoted.{Expr, Quotes}
 
-trait PathChunkMacros extends ViewBoundImplicit{
-  inline implicit def validatedStringChunk(s:String): PathChunk = ${validatedPathChunkImpl('s)}
+// StringPathChunkConversion is a fallback to non-macro String => PathChunk implicit conversion in case eta expansion is needed, this is required for ArrayPathChunk and SeqPathChunk
+trait PathChunkMacros extends StringPathChunkConversion{
+  inline implicit def stringPathChunkValidated(s:String): PathChunk = ${stringPathChunkValidatedImpl('s)}
 }
 
 object Macros {
-  def validatedPathChunkImpl(s:Expr[String])(using quotes: Quotes): Expr[SubPathChunk] = {
+  def stringPathChunkValidatedImpl(s:Expr[String])(using quotes: Quotes): Expr[SubPathChunk] = {
     import quotes.reflect.*
 
     s.asTerm match {

--- a/os/src-3/Macros.scala
+++ b/os/src-3/Macros.scala
@@ -1,0 +1,27 @@
+package os
+
+import os.Macros.validatedPathChunkImpl
+import os.PathChunk.SubPathChunk
+
+import scala.collection.immutable.IndexedSeq
+import scala.quoted.{Expr, Quotes}
+
+trait PathChunkMacros extends ViewBoundImplicit{
+  inline implicit def validatedStringChunk(s:String): PathChunk = ${validatedPathChunkImpl('s)}
+}
+
+object Macros {
+  def validatedPathChunkImpl(s:Expr[String])(using quotes: Quotes): Expr[SubPathChunk] = {
+    import quotes.reflect.*
+
+    s.asTerm match {
+      case Inlined(_, _, Literal(StringConstant(literal))) =>
+        val splitted = literal.splitWithDelimiters("/",-1).filterNot(_ == "/")
+        splitted.foreach(BasePath.checkSegment)
+
+        '{new SubPathChunk(SubPath.apply(${Expr(splitted)}.toIndexedSeq))}
+      case _ =>
+        '{{new SubPathChunk(SubPath.apply(IndexedSeq($s)))}}
+    }
+  }
+}

--- a/os/src-3/acyclic.scala
+++ b/os/src-3/acyclic.scala
@@ -1,0 +1,5 @@
+package os
+private[os] object acyclic {
+  /** Mocks [[\\import acyclic.skipped]] for scala 3 */
+  private[os] type skipped
+}

--- a/os/src-3/acyclic.scala
+++ b/os/src-3/acyclic.scala
@@ -1,5 +1,6 @@
 package os
 private[os] object acyclic {
+
   /** Mocks [[\\import acyclic.skipped]] for scala 3 */
   private[os] type skipped
 }

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -44,6 +44,11 @@ object PathChunk extends PathChunkMacros {
     def ups = 0
     override def toString() = s
   }
+  // binary compatibility shim
+  class StringPathChunk(s: String) extends StringPathChunkInternal(s)
+  // binary compatibility shim
+  def StringPathChunk(s: String) = new StringPathChunk(s)
+
   implicit class SymbolPathChunk(s: Symbol) extends PathChunk {
     BasePath.checkSegment(s.name)
     def segments = Seq(s.name)

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -13,8 +13,9 @@ trait PathChunk {
 }
 trait ViewBoundImplicit {
 
-  /** macros are not avaliable as implicit views, so this is needed for [[os.PathChunk.ArrayPathChunk]] to work */
-  implicit def validatedStringFun(s: String): PathChunk = new PathChunk.StringPathChunkInternal(s)
+  // fallback to non-macro String => PathChunk implicit conversion in case eta expansion is needed, this is required for ArrayPathChunk and SeqPathChunk
+  implicit def validatedStringFunction(s: String): PathChunk =
+    new PathChunk.StringPathChunkInternal(s)
 }
 
 object PathChunk extends PathChunkMacros {
@@ -37,7 +38,7 @@ object PathChunk extends PathChunkMacros {
     override def toString() = r.toString
   }
 
-  /** this needed for usages of [[/]] inside this project, as we cannot use macros in same compilation unit */
+  // Implicit String => PathChunk conversion used inside os-lib, prevents macro expansion in same compilation unit
   private[os] implicit class StringPathChunkInternal(s: String) extends PathChunk {
     BasePath.checkSegment(s)
     def segments = Seq(s)

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -11,10 +11,9 @@ trait PathChunk {
   def segments: Seq[String]
   def ups: Int
 }
-trait ViewBoundImplicit {
+trait StringPathChunkConversion {
 
-  // fallback to non-macro String => PathChunk implicit conversion in case eta expansion is needed, this is required for ArrayPathChunk and SeqPathChunk
-  implicit def validatedStringFunction(s: String): PathChunk =
+  implicit def stringToPathChunk(s: String): PathChunk =
     new PathChunk.StringPathChunkInternal(s)
 }
 

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -11,9 +11,10 @@ trait PathChunk {
   def segments: Seq[String]
   def ups: Int
 }
-trait ViewBoundImplicit{
-  /**macros are not avaliable as implicit views, so this is needed for [[os.PathChunk.ArrayPathChunk]] to work*/
-  implicit def validatedStringFun(s:String): PathChunk =  new PathChunk.StringPathChunkInternal(s)
+trait ViewBoundImplicit {
+
+  /** macros are not avaliable as implicit views, so this is needed for [[os.PathChunk.ArrayPathChunk]] to work */
+  implicit def validatedStringFun(s: String): PathChunk = new PathChunk.StringPathChunkInternal(s)
 }
 
 object PathChunk extends PathChunkMacros {
@@ -30,7 +31,7 @@ object PathChunk extends PathChunkMacros {
     override def toString() = r.toString
   }
 
-  /**this needed for usages of [[/]] inside this project, as we cannot use macros in same compilation unit*/
+  /** this needed for usages of [[/]] inside this project, as we cannot use macros in same compilation unit */
   private[os] implicit class StringPathChunkInternal(s: String) extends PathChunk {
     BasePath.checkSegment(s)
     def segments = Seq(s)

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -18,6 +18,12 @@ trait ViewBoundImplicit {
 }
 
 object PathChunk extends PathChunkMacros {
+  def segmentsFromString(s: String): Array[String] = {
+    val trailingSeparatorsCount = s.reverseIterator.takeWhile(_ == '/').length
+    val strNoTrailingSeps = s.dropRight(trailingSeparatorsCount)
+    val splitted = strNoTrailingSeps.split('/')
+    splitted ++ Array.fill(trailingSeparatorsCount)("")
+  }
 
   implicit class RelPathChunk(r: RelPath) extends PathChunk {
     def segments = r.segments

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -44,6 +44,7 @@ object PathChunk extends PathChunkMacros {
     def ups = 0
     override def toString() = s
   }
+
   // binary compatibility shim
   class StringPathChunk(s: String) extends StringPathChunkInternal(s)
 

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -46,8 +46,9 @@ object PathChunk extends PathChunkMacros {
   }
   // binary compatibility shim
   class StringPathChunk(s: String) extends StringPathChunkInternal(s)
+
   // binary compatibility shim
-  def StringPathChunk(s: String) = new StringPathChunk(s)
+  def StringPathChunk(s: String): StringPathChunk = new StringPathChunk(s)
 
   implicit class SymbolPathChunk(s: Symbol) extends PathChunk {
     BasePath.checkSegment(s.name)

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -20,7 +20,7 @@ trait StringPathChunkConversion {
 }
 
 object PathChunk extends PathChunkMacros {
-  def segmentsFromString(s: String): Array[String] = {
+  private[os] def segmentsFromString(s: String): Array[String] = {
     val trailingSeparatorsCount = s.reverseIterator.takeWhile(_ == '/').length
     val strNoTrailingSeps = s.dropRight(trailingSeparatorsCount)
     val splitted = strNoTrailingSeps.split('/')

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -8,32 +8,31 @@ import utest.{assert => _, _}
 
 import java.net.URI
 object PathTests extends TestSuite {
-  private def nonValidPathSegment(chars:String) = s"[$chars] is not a valid path segment."
+  private def nonValidPathSegment(chars: String) = s"[$chars] is not a valid path segment."
 
   val tests = Tests {
-    test("Literals"){
-      test("Basic"){
+    test("Literals") {
+      test("Basic") {
         assert(rel / "src" / "Main/.scala" == rel / "src" / "Main" / ".scala")
-        assert ( root / "core/src/test" == root / "core" / "src"/ "test")
-        assert ( root / "core/src/test" == root / "core" / "src/test")
+        assert(root / "core/src/test" == root / "core" / "src" / "test")
+        assert(root / "core/src/test" == root / "core" / "src/test")
       }
-      test("Compile errors"){
-        compileError(""" rel / "src" / "" """).check("",nonValidPathSegment(""))
+      test("Compile errors") {
+        compileError(""" rel / "src" / "" """).check("", nonValidPathSegment(""))
         compileError(""" rel / "src" / "." """).check("", nonValidPathSegment("."))
-        compileError(""" rel / "src" / ".." """).check("",nonValidPathSegment(".."))
+        compileError(""" rel / "src" / ".." """).check("", nonValidPathSegment(".."))
 
-        compileError { """ root / "src/"  """}.check("",nonValidPathSegment(""))
+        compileError { """ root / "src/"  """ }.check("", nonValidPathSegment(""))
         compileError { """ root / "src/." """ }.check("", nonValidPathSegment("."))
-        compileError { """ root / "src/.." """ }.check("",nonValidPathSegment(".."))
+        compileError { """ root / "src/.." """ }.check("", nonValidPathSegment(".."))
 
         compileError { """ root / "" """ }.check("", nonValidPathSegment(""))
         compileError { """ root / "." """ }.check("", nonValidPathSegment("."))
-        compileError { """ root / ".." """ }.check("",nonValidPathSegment(".."))
+        compileError { """ root / ".." """ }.check("", nonValidPathSegment(".."))
 
-
-        compileError(""" root / "hello" / ".." / "world" """).check("",nonValidPathSegment(".."))
-        compileError(""" root / "hello" / "../world" """).check("",nonValidPathSegment(".."))
-        compileError(""" root / "hello/../world" """).check("",nonValidPathSegment(".."))
+        compileError(""" root / "hello" / ".." / "world" """).check("", nonValidPathSegment(".."))
+        compileError(""" root / "hello" / "../world" """).check("", nonValidPathSegment(".."))
+        compileError(""" root / "hello/../world" """).check("", nonValidPathSegment(".."))
       }
     }
     test("Basic") {
@@ -307,8 +306,7 @@ object PathTests extends TestSuite {
       }
     }
     test("Errors") {
-      def nonLiteral(s:String) = s
-
+      def nonLiteral(s: String) = s
 
       test("InvalidChars") {
         val ex = intercept[PathError.InvalidSegment](rel / "src" / nonLiteral("Main/.scala"))

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -46,8 +46,6 @@ object PathTests extends TestSuite {
         assert(rel / "src" / "Main/.scala" == rel / "src" / "Main" / ".scala")
         assert(root / "core/src/test" == root / "core" / "src" / "test")
         assert(root / "core/src/test" == root / "core" / "src/test")
-        assert(root / "core/   " == root / "core" / "   ")
-        assert(root / " / " == root / " " / " ")
       }
       test("Compile errors") {
 

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -4,6 +4,7 @@ import java.nio.file.Paths
 import java.io.File
 import os._
 import os.Path.driveRoot
+import os.PathChunk.segmentsFromString
 import utest.{assert => _, _}
 
 import java.net.URI
@@ -11,6 +12,36 @@ object PathTests extends TestSuite {
   private def nonValidPathSegment(chars: String) = s"[$chars] is not a valid path segment."
 
   val tests = Tests {
+    test("segmentsFromString") {
+      def testSegmentsFromString(s: String, expected: List[String]) = {
+        assert(segmentsFromString(s).sameElements(expected))
+      }
+
+      testSegmentsFromString("  ", "  " :: Nil)
+
+      testSegmentsFromString("", "" :: Nil)
+
+      testSegmentsFromString("""foo/bar/baz""", "foo" :: "bar" :: "baz" :: Nil)
+
+      testSegmentsFromString("""/""", "" :: "" :: Nil)
+      testSegmentsFromString("""//""", "" :: "" :: "" :: Nil)
+      testSegmentsFromString("""///""", "" :: "" :: "" :: "" :: Nil)
+
+      testSegmentsFromString("""a/""", "a" :: "" :: Nil)
+      testSegmentsFromString("""a//""", "a" :: "" :: "" :: Nil)
+      testSegmentsFromString("""a///""", "a" :: "" :: "" :: "" :: Nil)
+
+      testSegmentsFromString("""ahs/""", "ahs" :: "" :: Nil)
+      testSegmentsFromString("""ahs//""", "ahs" :: "" :: "" :: Nil)
+
+      testSegmentsFromString("""ahs/aa/""", "ahs" :: "aa" :: "" :: Nil)
+      testSegmentsFromString("""ahs/aa/""", "ahs" :: "aa" :: "" :: Nil)
+      testSegmentsFromString("""ahs/aa//""", "ahs" :: "aa" :: "" :: "" :: Nil)
+
+      testSegmentsFromString("""/a""", "" :: "a" :: Nil)
+      testSegmentsFromString("""//a""", "" :: "" :: "a" :: Nil)
+      testSegmentsFromString("""//a/""", "" :: "" :: "a" :: "" :: Nil)
+    }
     test("Literals") {
       test("Basic") {
         assert(rel / "src" / "Main/.scala" == rel / "src" / "Main" / ".scala")

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -4,7 +4,6 @@ import java.nio.file.Paths
 import java.io.File
 import os._
 import os.Path.driveRoot
-import os.PathChunk.segmentsFromString
 import utest.{assert => _, _}
 
 import java.net.URI
@@ -15,35 +14,6 @@ object PathTests extends TestSuite {
     s"Literal path sequence [$literal] doesn't affect path being formed, please remove it"
 
   val tests = Tests {
-    test("segmentsFromString") {
-      def testSegmentsFromString(s: String, expected: List[String]) = {
-        assert(segmentsFromString(s).sameElements(expected))
-      }
-
-      testSegmentsFromString("  ", List("  "))
-
-      testSegmentsFromString("", List(""))
-
-      testSegmentsFromString("""foo/bar/baz""", List("foo", "bar", "baz"))
-
-      testSegmentsFromString("""/""", List("", ""))
-      testSegmentsFromString("""//""", List("", "", ""))
-      testSegmentsFromString("""///""", List("", "", "", ""))
-
-      testSegmentsFromString("""a/""", List("a", ""))
-      testSegmentsFromString("""a//""", List("a", "", ""))
-      testSegmentsFromString("""a///""", List("a", "", "", ""))
-
-      testSegmentsFromString("""ahs/""", List("ahs", ""))
-      testSegmentsFromString("""ahs//""", List("ahs", "", ""))
-
-      testSegmentsFromString("""ahs/aa/""", List("ahs", "aa", ""))
-      testSegmentsFromString("""ahs/aa//""", List("ahs", "aa", "", ""))
-
-      testSegmentsFromString("""/a""", List("", "a"))
-      testSegmentsFromString("""//a""", List("", "", "a"))
-      testSegmentsFromString("""//a/""", List("", "", "a", ""))
-    }
     test("Literals") {
       test("Basic") {
         assert(rel / "src" / "Main/.scala" == rel / "src" / "Main" / ".scala")

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -35,7 +35,6 @@ object PathTests extends TestSuite {
       testSegmentsFromString("""ahs//""", "ahs" :: "" :: "" :: Nil)
 
       testSegmentsFromString("""ahs/aa/""", "ahs" :: "aa" :: "" :: Nil)
-      testSegmentsFromString("""ahs/aa/""", "ahs" :: "aa" :: "" :: Nil)
       testSegmentsFromString("""ahs/aa//""", "ahs" :: "aa" :: "" :: "" :: Nil)
 
       testSegmentsFromString("""/a""", "" :: "a" :: Nil)
@@ -47,8 +46,27 @@ object PathTests extends TestSuite {
         assert(rel / "src" / "Main/.scala" == rel / "src" / "Main" / ".scala")
         assert(root / "core/src/test" == root / "core" / "src" / "test")
         assert(root / "core/src/test" == root / "core" / "src/test")
+        assert(root / "core/   " == root / "core" / "   ")
+        assert(root / " / " == root / " " / " ")
       }
       test("Compile errors") {
+
+        compileError("""root / "/" """).check("", nonValidPathSegment(""))
+        compileError("""root / "/ " """).check("", nonValidPathSegment(""))
+        compileError("""root / " /" """).check("", nonValidPathSegment(""))
+        compileError("""root / "//" """).check("", nonValidPathSegment(""))
+
+        compileError("""root / "foo/" """).check("", nonValidPathSegment(""))
+        compileError("""root / "foo//" """).check("", nonValidPathSegment(""))
+
+        compileError("""root / "foo/bar/" """).check("", nonValidPathSegment(""))
+        compileError("""root / "foo/bar//" """).check("", nonValidPathSegment(""))
+
+        compileError("""root / "/foo" """).check("", nonValidPathSegment(""))
+        compileError("""root / "//foo" """).check("", nonValidPathSegment(""))
+
+        compileError("""root / "//foo/" """).check("", nonValidPathSegment(""))
+
         compileError(""" rel / "src" / "" """).check("", nonValidPathSegment(""))
         compileError(""" rel / "src" / "." """).check("", nonValidPathSegment("."))
         compileError(""" rel / "src" / ".." """).check("", nonValidPathSegment(".."))

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -11,14 +11,6 @@ object PathTests extends TestSuite {
   private def nonValidPathSegment(chars:String) = s"[$chars] is not a valid path segment."
 
   val tests = Tests {
-    test("Temp") {
-//      os.pwd / "."
-//      Macros.validateLiteralPath("")
-//      Macros.validateLiteralPath(".")
-//      Macros.validateLiteralPath("..")
-//      Macros.validateLiteralPath("./b")
-    }
-
     test("Literals"){
       test("Basic"){
         assert(rel / "src" / "Main/.scala" == rel / "src" / "Main" / ".scala")

--- a/os/test/src/SegmentsFromStringTests.scala
+++ b/os/test/src/SegmentsFromStringTests.scala
@@ -1,0 +1,39 @@
+package os
+
+import os.PathChunk.segmentsFromString
+import utest.{assert => _, _}
+
+object SegmentsFromStringTests extends TestSuite {
+
+  val tests = Tests {
+    test("segmentsFromString") {
+      def testSegmentsFromString(s: String, expected: List[String]) = {
+        assert(segmentsFromString(s).sameElements(expected))
+      }
+
+      testSegmentsFromString("  ", List("  "))
+
+      testSegmentsFromString("", List(""))
+
+      testSegmentsFromString("""foo/bar/baz""", List("foo", "bar", "baz"))
+
+      testSegmentsFromString("""/""", List("", ""))
+      testSegmentsFromString("""//""", List("", "", ""))
+      testSegmentsFromString("""///""", List("", "", "", ""))
+
+      testSegmentsFromString("""a/""", List("a", ""))
+      testSegmentsFromString("""a//""", List("a", "", ""))
+      testSegmentsFromString("""a///""", List("a", "", "", ""))
+
+      testSegmentsFromString("""ahs/""", List("ahs", ""))
+      testSegmentsFromString("""ahs//""", List("ahs", "", ""))
+
+      testSegmentsFromString("""ahs/aa/""", List("ahs", "aa", ""))
+      testSegmentsFromString("""ahs/aa//""", List("ahs", "aa", "", ""))
+
+      testSegmentsFromString("""/a""", List("", "a"))
+      testSegmentsFromString("""//a""", List("", "", "a"))
+      testSegmentsFromString("""//a/""", List("", "", "a", ""))
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for multi-segment literal strings.
for example
```scala
val path = root / "foo/bar" 
val qux = "qux"
val path = root / "foo/bar" / "baz" / qux
val path = root / "foo/bar" / "baz/qux"
```
it also parses `..` segments from literal as `os.up` enabling syntax like:
```scala
val path = root / "foo" / ".." / "bar" // equivalent to `root / "foo" / os.up / "bar"`
val path = root / "foo" /  "../bar" // equivalent to `root / "foo" / os.up / "bar"`
```
non-canonical paths used in literals result in compile-time errors, suggesting usage of canonical paths or removing path segment, eg.
```scala
val path = root / "foo/./bar" //suggests "foo/bar"
val path = root / "foo//bar" //suggests "foo/bar"
val path = root / "//foo//bar/./baz" //suggests "foo/bar/baz"

val path = root / ""  //suggests removing the segment
val path = root / "." //suggests removing the segment
val path = root / "/" //suggests removing the segment
val path = root / "//" //suggests removing the segment
val path = root / "/./" //suggests removing the segment

```

Note:
Its not usable in os-Lib itself, due to the fact that it would lead to macro expansion in the same compilation unit as its definition.

@lihaoyi 
there is a little bit of hacking involved:

1. There is a default implicit conversion not being a macro to be used within os library, without this we would have to add a submodule and split the whole project, I'm not even sure if its doable.
4. Needed to turn off acyclic in `Path` and particular `Macro` files (also needed to mock `acyclic.skipped` in case of `scala 3`).
5. Needed to provide another implicit conversion in `ViewBoundImplicit` trait because macros turn out to be not avaliable as implicit views, this is needed for `ArrayPathChunk` and `SeqPathChunk` to work.