### PR TITLE
Make `os.pwd` modifiable via the `os.pwd0` dynamic variable

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -1815,8 +1815,8 @@ wd / os.up
 wd / os.up / os.up
 ----
 
-Note that there are no in-built operations to change the `os.pwd`. In general,
-you should not need to: simply defining a new path, e.g.
+`os.pwd` can be modified in certain scopes via the `os.pwd0` dynamic variable, but
+best practice is not to change it. Instead simply define a new path, e.g.
 
 [source,scala]
 ----

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -1815,7 +1815,7 @@ wd / os.up
 wd / os.up / os.up
 ----
 
-`os.pwd` can be modified in certain scopes via the `os.pwd0` dynamic variable, but
+`os.pwd` can be modified in certain scopes via the `os.dynamicPwd` dynamic variable, but
 best practice is not to change it. Instead simply define a new path, e.g.
 
 [source,scala]

--- a/os/src-jvm/package.scala
+++ b/os/src-jvm/package.scala
@@ -39,9 +39,9 @@ package object os {
   /**
    * The current working directory for this process.
    */
-  val pwd: Path = pwd0.value
+  def pwd: Path = pwd0.value
   val pwd0: DynamicVariable[Path] =
-    DynamicVariable(os.Path(java.nio.file.Paths.get(".").toAbsolutePath))
+    new DynamicVariable(os.Path(java.nio.file.Paths.get(".").toAbsolutePath))
 
   val up: RelPath = RelPath.up
 

--- a/os/src-jvm/package.scala
+++ b/os/src-jvm/package.scala
@@ -39,8 +39,8 @@ package object os {
   /**
    * The current working directory for this process.
    */
-  def pwd: Path = pwd0.value
-  val pwd0: DynamicVariable[Path] =
+  def pwd: Path = dynamicPwd.value
+  val dynamicPwd: DynamicVariable[Path] =
     new DynamicVariable(os.Path(java.nio.file.Paths.get(".").toAbsolutePath))
 
   val up: RelPath = RelPath.up

--- a/os/src-jvm/package.scala
+++ b/os/src-jvm/package.scala
@@ -2,6 +2,7 @@ import scala.language.implicitConversions
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Paths
+import scala.util.DynamicVariable
 
 package object os {
   type Generator[+T] = geny.Generator[T]
@@ -38,7 +39,9 @@ package object os {
   /**
    * The current working directory for this process.
    */
-  val pwd: Path = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
+  val pwd: Path = pwd0.value
+  val pwd0: DynamicVariable[Path] =
+    DynamicVariable(os.Path(java.nio.file.Paths.get(".").toAbsolutePath))
 
   val up: RelPath = RelPath.up
 

--- a/os/src-native/package.scala
+++ b/os/src-native/package.scala
@@ -1,5 +1,6 @@
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
+import scala.util.DynamicVariable
 package object os {
   type Generator[+T] = geny.Generator[T]
   val Generator = geny.Generator
@@ -31,7 +32,9 @@ package object os {
   /**
    * The current working directory for this process.
    */
-  val pwd: Path = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
+  val pwd: Path = pwd0.value
+  val pwd0: DynamicVariable[Path] =
+    DynamicVariable(os.Path(java.nio.file.Paths.get(".").toAbsolutePath))
 
   val up: RelPath = RelPath.up
 

--- a/os/src-native/package.scala
+++ b/os/src-native/package.scala
@@ -32,8 +32,8 @@ package object os {
   /**
    * The current working directory for this process.
    */
-  def pwd: Path = pwd0.value
-  val pwd0: DynamicVariable[Path] =
+  def pwd: Path = dynamicPwd.value
+  val dynamicPwd: DynamicVariable[Path] =
     new DynamicVariable(os.Path(java.nio.file.Paths.get(".").toAbsolutePath))
 
   val up: RelPath = RelPath.up

--- a/os/src-native/package.scala
+++ b/os/src-native/package.scala
@@ -32,9 +32,9 @@ package object os {
   /**
    * The current working directory for this process.
    */
-  val pwd: Path = pwd0.value
+  def pwd: Path = pwd0.value
   val pwd0: DynamicVariable[Path] =
-    DynamicVariable(os.Path(java.nio.file.Paths.get(".").toAbsolutePath))
+    new DynamicVariable(os.Path(java.nio.file.Paths.get(".").toAbsolutePath))
 
   val up: RelPath = RelPath.up
 

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -434,6 +434,14 @@ object PathTests extends TestSuite {
       System.err.printf("p[%s]\n", posix(p))
       assert(posix(p) contains "/omg")
     }
+    test("pwd0") {
+      val x = os.pwd
+      val y = os.pwd0.withValue(os.pwd / "hello") {
+        os.pwd
+      }
+
+      assert(x / "hello" == y)
+    }
   }
   // compare absolute paths
   def sameFile(a: java.nio.file.Path, b: java.nio.file.Path): Boolean = {

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -434,9 +434,9 @@ object PathTests extends TestSuite {
       System.err.printf("p[%s]\n", posix(p))
       assert(posix(p) contains "/omg")
     }
-    test("pwd0") {
+    test("dynamicPwd") {
       val x = os.pwd
-      val y = os.pwd0.withValue(os.pwd / "hello") {
+      val y = os.dynamicPwd.withValue(os.pwd / "hello") {
         os.pwd
       }
 

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -203,5 +203,21 @@ object SubprocessTests extends TestSuite {
         assert(output.out.lines() == Seq("HELLO /usr"))
       }
     }
+    test("pwd0") {
+
+      val outsidePwd = os.pwd
+      val tmp0 = os.temp.dir()
+      val tmp = os.followLink(tmp0).getOrElse(tmp0)
+      val x = proc("bash", "-c", "pwd").call()
+      val y = os.pwd0.withValue(tmp) {
+        proc("bash", "-c", "pwd").call()
+      }
+
+      val z = proc("bash", "-c", "pwd").call()
+      assert(outsidePwd.toString != tmp.toString)
+      assert(x.out.trim() == outsidePwd.toString)
+      assert(y.out.trim() == tmp.toString)
+      assert(z.out.trim() == outsidePwd.toString)
+    }
   }
 }

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -204,20 +204,23 @@ object SubprocessTests extends TestSuite {
       }
     }
     test("pwd0") {
+      // Windows doesnt have bash installed so a bit inconvenient 
+      // to run these subprocesses for testing
+      if (!scala.util.Properties.isWin) {
+        val outsidePwd = os.pwd
+        val tmp0 = os.temp.dir()
+        val tmp = os.followLink(tmp0).getOrElse(tmp0)
+        val x = proc("bash", "-c", "pwd").call()
+        val y = os.pwd0.withValue(tmp) {
+          proc("bash", "-c", "pwd").call()
+        }
 
-      val outsidePwd = os.pwd
-      val tmp0 = os.temp.dir()
-      val tmp = os.followLink(tmp0).getOrElse(tmp0)
-      val x = proc("bash", "-c", "pwd").call()
-      val y = os.pwd0.withValue(tmp) {
-        proc("bash", "-c", "pwd").call()
+        val z = proc("bash", "-c", "pwd").call()
+        assert(outsidePwd.toString != tmp.toString)
+        assert(x.out.trim() == outsidePwd.toString)
+        assert(y.out.trim() == tmp.toString)
+        assert(z.out.trim() == outsidePwd.toString)
       }
-
-      val z = proc("bash", "-c", "pwd").call()
-      assert(outsidePwd.toString != tmp.toString)
-      assert(x.out.trim() == outsidePwd.toString)
-      assert(y.out.trim() == tmp.toString)
-      assert(z.out.trim() == outsidePwd.toString)
     }
   }
 }

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -204,7 +204,7 @@ object SubprocessTests extends TestSuite {
       }
     }
     test("pwd0") {
-      // Windows doesnt have bash installed so a bit inconvenient 
+      // Windows doesnt have bash installed so a bit inconvenient
       // to run these subprocesses for testing
       if (!scala.util.Properties.isWin) {
         val outsidePwd = os.pwd

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -203,7 +203,7 @@ object SubprocessTests extends TestSuite {
         assert(output.out.lines() == Seq("HELLO /usr"))
       }
     }
-    test("pwd0") {
+    test("dynamicPwd") {
       // Windows doesnt have bash installed so a bit inconvenient
       // to run these subprocesses for testing
       if (!scala.util.Properties.isWin) {
@@ -211,7 +211,7 @@ object SubprocessTests extends TestSuite {
         val tmp0 = os.temp.dir()
         val tmp = os.followLink(tmp0).getOrElse(tmp0)
         val x = proc("bash", "-c", "pwd").call()
-        val y = os.pwd0.withValue(tmp) {
+        val y = os.dynamicPwd.withValue(tmp) {
           proc("bash", "-c", "pwd").call()
         }
 


### PR DESCRIPTION
Basically the same thing we did in https://github.com/com-lihaoyi/os-lib/pull/295 and https://github.com/com-lihaoyi/os-lib/pull/283, except rather than being `os.SubProcess`-specific this applies to all usage of `os.pwd`. And with similar limitations: this works for code paths that go through OS-Lib, but not for code that uses `java.io` or `java.nio` directly.

AFAIK this is the last of the "global" things we need to redirect in Mill tasks, after env variables and default subprocess streams. I'd like it to go into Mill 0.12.0 together with the other sandboxing-related changes

Added unit tests and updated the documentation

Pull Request: https://github.com/com-lihaoyi/os-lib/pull/298