### PR TITLE
Allow even more dynamic instrumentation of `pwd` via `os.dynamicPwdFunction`

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -2247,6 +2247,11 @@ string, int or set representations of the `os.PermSet` via:
 
 == Changelog
 
+[#main]
+=== main
+
+* Make `os.pwd` modifiable via the `os.dynamicPwd0`
+
 [#0-10-6]
 === 0.10.6
 

--- a/os/src-jvm/package.scala
+++ b/os/src-jvm/package.scala
@@ -39,9 +39,19 @@ package object os {
   /**
    * The current working directory for this process.
    */
-  def pwd: Path = dynamicPwd.value
-  val dynamicPwd: DynamicVariable[Path] =
-    new DynamicVariable(os.Path(java.nio.file.Paths.get(".").toAbsolutePath))
+  def pwd: Path = dynamicPwdFunction.value()
+
+  private val pwd0 = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
+
+  /**
+   * Used to override `pwd` within a certain scope with a generated value
+   */
+  val dynamicPwdFunction: DynamicVariable[() => Path] = new DynamicVariable(() => dynamicPwd.value)
+
+  /**
+   * Used to override `pwd` within a certain scope with a fixed value
+   */
+  val dynamicPwd: DynamicVariable[Path] = new DynamicVariable(pwd0)
 
   val up: RelPath = RelPath.up
 

--- a/os/src-native/package.scala
+++ b/os/src-native/package.scala
@@ -32,9 +32,19 @@ package object os {
   /**
    * The current working directory for this process.
    */
-  def pwd: Path = dynamicPwd.value
-  val dynamicPwd: DynamicVariable[Path] =
-    new DynamicVariable(os.Path(java.nio.file.Paths.get(".").toAbsolutePath))
+  def pwd: Path = dynamicPwdFunction.value()
+
+  private val pwd0 = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
+
+  /**
+   * Used to override `pwd` within a certain scope with a generated value
+   */
+  val dynamicPwdFunction: DynamicVariable[() => Path] = new DynamicVariable(() => dynamicPwd.value)
+
+  /**
+   * Used to override `pwd` within a certain scope with a fixed value
+   */
+  val dynamicPwd: DynamicVariable[Path] = new DynamicVariable(pwd0)
 
   val up: RelPath = RelPath.up
 


### PR DESCRIPTION
Follow up to https://github.com/com-lihaoyi/os-lib/pull/298, which it turns out was not flexible enough to do what we need in Mill. Mill uses references to the `pwd` to create the `.dest` folder lazily, thus we cannot just assign a value to the `os.pwd` but actually need to assign a lambda that can be replaced to implement the lazy evaluation

I pulled the trigger too quickly on releasing 0.10.6 with `os.dynamicPwd`, so this one has to be named differently. I chose `os.dynamicPwdFunction` and will make sure to test it with an unstable release before releasing a stable tag