### PR TITLE
Update error messages to allow better error messages for invalid path segments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: ci
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -19,3 +19,6 @@ newlines.source = keep
 
 runner.dialect = scala213
 
+project.excludePaths = [
+    "glob:**/src-3/**"
+]

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -2250,7 +2250,7 @@ string, int or set representations of the `os.PermSet` via:
 [#main]
 === main
 
-* Make `os.pwd` modifiable via the `os.dynamicPwd0`
+* Allow multi-segment paths segments for literals https://github.com/com-lihaoyi/os-lib/pull/297
 
 [#0-10-6]
 === 0.10.6

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -172,7 +172,7 @@ object BasePath {
     def fail(msg: String) = throw PathError.InvalidSegment(s, msg)
     def considerStr =
       "If you are dealing with dynamic path-strings coming from external sources, " +
-      "use the Path(...)/RelPath(...)/SubPath(...) constructor calls to convert them."
+        "use the Path(...)/RelPath(...)/SubPath(...) constructor calls to convert them."
 
     s.indexOf('/') match {
       case -1 => // do nothing

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -171,34 +171,31 @@ object BasePath {
   def checkSegment(s: String) = {
     def fail(msg: String) = throw PathError.InvalidSegment(s, msg)
     def considerStr =
-      "use the Path(...) or RelPath(...) constructor calls to convert them. "
+      "If you are dealing with dynamic path-strings coming from external sources, " +
+      "use the Path(...)/RelPath(...)/SubPath(...) constructor calls to convert them."
 
     s.indexOf('/') match {
       case -1 => // do nothing
       case c => fail(
-          s"[/] is not a valid character to appear in a path segment. " +
-            "If you want to parse an absolute or relative path that may have " +
-            "multiple segments, e.g. path-strings coming from external sources " +
+          s"[/] is not a valid character to appear in a non-literal path segment. " +
             considerStr
         )
 
     }
-    def externalStr = "If you are dealing with path-strings coming from external sources, "
     s match {
       case "" =>
         fail(
-          "OS-Lib does not allow empty path segments " +
-            externalStr + considerStr
+          "OS-Lib does not allow empty path segments. " +
+            considerStr
         )
       case "." =>
         fail(
-          "OS-Lib does not allow [.] as a path segment " +
-            externalStr + considerStr
+          "OS-Lib does not allow [.] in a non-literal path segment. " +
+            considerStr
         )
       case ".." =>
         fail(
-          "OS-Lib does not allow [..] as a path segment " +
-            externalStr +
+          "OS-Lib does not allow [..] in a non-literal path segment. " +
             considerStr +
             "If you want to use the `..` segment manually to represent going up " +
             "one level in the path, use the `up` segment from `os.up` " +

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -340,9 +340,9 @@ object PathTests extends TestSuite {
 
         assert(
           msg1.contains(
-            "[/] is not a valid character to appear in a non-literal path segment. If you are "+
-            "dealing with dynamic path-strings coming from external sources, use the "+
-            "Path(...)/RelPath(...)/SubPath(...) constructor calls to convert them."
+            "[/] is not a valid character to appear in a non-literal path segment. If you are " +
+              "dealing with dynamic path-strings coming from external sources, use the " +
+              "Path(...)/RelPath(...)/SubPath(...) constructor calls to convert them."
           )
         )
 

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -338,7 +338,13 @@ object PathTests extends TestSuite {
 
         val PathError.InvalidSegment("Main/.scala", msg1) = ex
 
-        assert(msg1.contains("[/] is not a valid character to appear in a path segment"))
+        assert(
+          msg1.contains(
+            "[/] is not a valid character to appear in a non-literal path segment. If you are "+
+            "dealing with dynamic path-strings coming from external sources, use the "+
+            "Path(...)/RelPath(...)/SubPath(...) constructor calls to convert them."
+          )
+        )
 
         val ex2 = intercept[PathError.InvalidSegment](root / "hello" / nonLiteral("..") / "world")
 


### PR DESCRIPTION
Since https://github.com/com-lihaoyi/os-lib/pull/297 landed, the old error messages have become somewhat misleading. This attempts to make them a bit more accurate, and suggest to users that literal string path segments have more flexibility than dynamically computed ones