### PR TITLE
Make use of concise literal paths everywhere

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -19,7 +19,7 @@ image:https://javadoc.io/badge2/com.lihaoyi/os-lib_3/scaladoc.svg[API Docs (Scal
 [source,scala]
 ----
 // Make sure working directory exists and is empty
-val wd = os.pwd/"out"/"splash"
+val wd = os.pwd/"out/splash"
 os.remove.all(wd)
 os.makeDir.all(wd)
 
@@ -179,9 +179,9 @@ val largestThree = os.walk(wd)
   .take(3)
 
 largestThree ==> Seq(
-  (711, wd / "misc" / "binary.png"),
+  (711, wd / "misc/binary.png"),
   (81, wd / "Multi Line.txt"),
-  (22, wd / "folder1" / "one.txt")
+  (22, wd / "folder1/one.txt")
 )
 ----
 
@@ -229,7 +229,7 @@ read from if the source supports seeking.
 [source,scala]
 ----
 os.read(wd / "File.txt") ==> "I am cow"
-os.read(wd / "folder1" / "one.txt") ==> "Contents of folder one"
+os.read(wd / "folder1/one.txt") ==> "Contents of folder one"
 os.read(wd / "Multi Line.txt") ==>
   """I am cow
     |Hear me moo
@@ -252,7 +252,7 @@ supports seeking.
 [source,scala]
 ----
 os.read.bytes(wd / "File.txt") ==> "I am cow".getBytes
-os.read.bytes(wd / "misc" / "binary.png").length ==> 711
+os.read.bytes(wd / "misc/binary.png").length ==> 711
 ----
 
 ==== `os.read.chunks`
@@ -436,9 +436,9 @@ os.write.append(wd / "File.txt", ",\nI weigh twice as much as you")
 os.read(wd / "File.txt") ==>
   "I am cow, hear me moo,\nI weigh twice as much as you"
 
-os.read.bytes(wd / "misc" / "binary.png").length ==> 711
-os.write.append(wd / "misc" / "binary.png", Array[Byte](1, 2, 3))
-os.read.bytes(wd / "misc" / "binary.png").length ==> 714
+os.read.bytes(wd / "misc/binary.png").length ==> 711
+os.write.append(wd / "misc/binary.png", Array[Byte](1, 2, 3))
+os.read.bytes(wd / "misc/binary.png").length ==> 714
 ----
 
 ==== `os.write.over`
@@ -535,10 +535,10 @@ them. You can disable sorted by passing in the flag `sort = false`.
 
 [source,scala]
 ----
-os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
+os.list(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
 os.list(wd / "folder2") ==> Seq(
-  wd / "folder2" / "nestedA",
-  wd / "folder2" / "nestedB"
+  wd / "folder2/nestedA",
+  wd / "folder2/nestedB"
 )
 ----
 
@@ -598,35 +598,35 @@ if `preOrder = false`.
 
 [source,scala]
 ----
-os.walk(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
+os.walk(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
 
 os.walk(wd / "folder1", includeTarget = true) ==> Seq(
   wd / "folder1",
-  wd / "folder1" / "one.txt"
+  wd / "folder1/one.txt"
 )
 
 os.walk(wd / "folder2") ==> Seq(
-  wd / "folder2" / "nestedA",
-  wd / "folder2" / "nestedA" / "a.txt",
-  wd / "folder2" / "nestedB",
-  wd / "folder2" / "nestedB" / "b.txt"
+  wd / "folder2/nestedA",
+  wd / "folder2/nestedA/a.txt",
+  wd / "folder2/nestedB",
+  wd / "folder2/nestedB/b.txt"
 )
 
 os.walk(wd / "folder2", preOrder = false) ==> Seq(
-  wd / "folder2" / "nestedA" / "a.txt",
-  wd / "folder2" / "nestedA",
-  wd / "folder2" / "nestedB" / "b.txt",
-  wd / "folder2" / "nestedB"
+  wd / "folder2/nestedA/a.txt",
+  wd / "folder2/nestedA",
+  wd / "folder2/nestedB/b.txt",
+  wd / "folder2/nestedB"
 )
 
 os.walk(wd / "folder2", maxDepth = 1) ==> Seq(
-  wd / "folder2" / "nestedA",
-  wd / "folder2" / "nestedB"
+  wd / "folder2/nestedA",
+  wd / "folder2/nestedB"
 )
 
 os.walk(wd / "folder2", skip = _.last == "nestedA") ==> Seq(
-  wd / "folder2" / "nestedB",
-  wd / "folder2" / "nestedB" / "b.txt"
+  wd / "folder2/nestedB",
+  wd / "folder2/nestedB/b.txt"
 )
 ----
 
@@ -655,11 +655,11 @@ val filesSortedBySize = os.walk.attrs(wd / "misc", followLinks = true)
   .collect{case (p, attrs) if attrsisFile => p}
 
 filesSortedBySize ==> Seq(
-  wd / "misc" / "echo",
-  wd / "misc" / "file-symlink",
-  wd / "misc" / "echo_with_wd",
-  wd / "misc" / "folder-symlink" / "one.txt",
-  wd / "misc" / "binary.png"
+  wd / "misc/echo",
+  wd / "misc/file-symlink",
+  wd / "misc/echo_with_wd",
+  wd / "misc/folder-symlink/one.txt",
+  wd / "misc/binary.png"
 )
 ----
 
@@ -732,10 +732,10 @@ os.exists(wd / "File.txt") ==> true
 os.exists(wd / "folder1") ==> true
 os.exists(wd / "doesnt-exist") ==> false
 
-os.exists(wd / "misc" / "file-symlink") ==> true
-os.exists(wd / "misc" / "folder-symlink") ==> true
-os.exists(wd / "misc" / "broken-symlink") ==> false
-os.exists(wd / "misc" / "broken-symlink", followLinks = false) ==> true
+os.exists(wd / "misc/file-symlink") ==> true
+os.exists(wd / "misc/folder-symlink") ==> true
+os.exists(wd / "misc/broken-symlink") ==> false
+os.exists(wd / "misc/broken-symlink", followLinks = false) ==> true
 ----
 
 ==== `os.move`
@@ -751,13 +751,13 @@ path already exists, or is within the source path.
 
 [source,scala]
 ----
-os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
-os.move(wd / "folder1" / "one.txt", wd / "folder1" / "first.txt")
-os.list(wd / "folder1") ==> Seq(wd / "folder1" / "first.txt")
+os.list(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
+os.move(wd / "folder1/one.txt", wd / "folder1/first.txt")
+os.list(wd / "folder1") ==> Seq(wd / "folder1/first.txt")
 
-os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedA", wd / "folder2" / "nestedB")
-os.move(wd / "folder2" / "nestedA", wd / "folder2" / "nestedC")
-os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedB", wd / "folder2" / "nestedC")
+os.list(wd / "folder2") ==> Seq(wd / "folder2/nestedA", wd / "folder2/nestedB")
+os.move(wd / "folder2/nestedA", wd / "folder2/nestedC")
+os.list(wd / "folder2") ==> Seq(wd / "folder2/nestedB", wd / "folder2/nestedC")
 
 os.read(wd / "File.txt") ==> "I am cow"
 os.move(wd / "Multi Line.txt", wd / "File.txt", replaceExisting = true)
@@ -783,19 +783,19 @@ e.g. to rename all `.txt` files within a folder tree to `.data`:
 ----
 import os.{GlobSyntax, /}
 os.walk(wd / "folder2") ==> Seq(
-  wd / "folder2" / "nestedA",
-  wd / "folder2" / "nestedA" / "a.txt",
-  wd / "folder2" / "nestedB",
-  wd / "folder2" / "nestedB" / "b.txt"
+  wd / "folder2/nestedA",
+  wd / "folder2/nestedA/a.txt",
+  wd / "folder2/nestedB",
+  wd / "folder2/nestedB/b.txt"
 )
 
 os.walk(wd/'folder2).collect(os.move.matching{case p/g"$x.txt" => p/g"$x.data"})
 
 os.walk(wd / "folder2") ==> Seq(
-  wd / "folder2" / "nestedA",
-  wd / "folder2" / "nestedA" / "a.data",
-  wd / "folder2" / "nestedB",
-  wd / "folder2" / "nestedB" / "b.data"
+  wd / "folder2/nestedA",
+  wd / "folder2/nestedA/a.data",
+  wd / "folder2/nestedB",
+  wd / "folder2/nestedB/b.data"
 )
 ----
 
@@ -810,9 +810,9 @@ Move the given file or folder _into_ the destination folder
 
 [source,scala]
 ----
-os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
+os.list(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
 os.move.into(wd / "File.txt", wd / "folder1")
-os.list(wd / "folder1") ==> Seq(wd / "folder1" / "File.txt", wd / "folder1" / "one.txt")
+os.list(wd / "folder1") ==> Seq(wd / "folder1/File.txt", wd / "folder1/one.txt")
 ----
 
 ==== `os.move.over`
@@ -827,9 +827,9 @@ folder than may already be present at that path
 
 [source,scala]
 ----
-os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedA", wd / "folder2" / "nestedB")
+os.list(wd / "folder2") ==> Seq(wd / "folder2/nestedA", wd / "folder2/nestedB")
 os.move.over(wd / "folder1", wd / "folder2")
-os.list(wd / "folder2") ==> Seq(wd / "folder2" / "one.txt")
+os.list(wd / "folder2") ==> Seq(wd / "folder2/one.txt")
 ----
 
 ==== `os.copy`
@@ -846,16 +846,16 @@ within the source path.
 
 [source,scala]
 ----
-os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
-os.copy(wd / "folder1" / "one.txt", wd / "folder1" / "first.txt")
-os.list(wd / "folder1") ==> Seq(wd / "folder1" / "first.txt", wd / "folder1" / "one.txt")
+os.list(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
+os.copy(wd / "folder1/one.txt", wd / "folder1/first.txt")
+os.list(wd / "folder1") ==> Seq(wd / "folder1/first.txt", wd / "folder1/one.txt")
 
-os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedA", wd / "folder2" / "nestedB")
-os.copy(wd / "folder2" / "nestedA", wd / "folder2" / "nestedC")
+os.list(wd / "folder2") ==> Seq(wd / "folder2/nestedA", wd / "folder2/nestedB")
+os.copy(wd / "folder2/nestedA", wd / "folder2/nestedC")
 os.list(wd / "folder2") ==> Seq(
-  wd / "folder2" / "nestedA",
-  wd / "folder2" / "nestedB",
-  wd / "folder2" / "nestedC"
+  wd / "folder2/nestedA",
+  wd / "folder2/nestedB",
+  wd / "folder2/nestedC"
 )
 
 os.read(wd / "File.txt") ==> "I am cow"
@@ -892,9 +892,9 @@ Copy the given file or folder _into_ the destination folder
 
 [source,scala]
 ----
-os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
+os.list(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
 os.copy.into(wd / "File.txt", wd / "folder1")
-os.list(wd / "folder1") ==> Seq(wd / "folder1" / "File.txt", wd / "folder1" / "one.txt")
+os.list(wd / "folder1") ==> Seq(wd / "folder1/File.txt", wd / "folder1/one.txt")
 ----
 
 ==== `os.copy.over`
@@ -909,9 +909,9 @@ overwrite it instead of erroring out.
 
 [source,scala]
 ----
-os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedA", wd / "folder2" / "nestedB")
+os.list(wd / "folder2") ==> Seq(wd / "folder2/nestedA", wd / "folder2/nestedB")
 os.copy.over(wd / "folder1", wd / "folder2")
-os.list(wd / "folder2") ==> Seq(wd / "folder2" / "one.txt")
+os.list(wd / "folder2") ==> Seq(wd / "folder2/one.txt")
 ----
 
 ==== `os.copy` with `mergeFolders`
@@ -923,10 +923,10 @@ you can use the `mergeFolders` option of <<os-copy>>.
 
 [source,scala]
 ----
-os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
-os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedA", wd / "folder2" / "nestedB")
+os.list(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
+os.list(wd / "folder2") ==> Seq(wd / "folder2/nestedA", wd / "folder2/nestedB")
 os.copy(wd / "folder1", wd / "folder2", mergeFolders = true)
-os.list(wd / "folder2") ==> Seq(wd / "folder2" / "one.txt", wd / "folder2" / "nestedA", wd / "folder2" / "nestedB")
+os.list(wd / "folder2") ==> Seq(wd / "folder2/one.txt", wd / "folder2/nestedA", wd / "folder2/nestedB")
 ----
 
 ==== `os.makeDir`
@@ -972,8 +972,8 @@ to error out in that case by passing in `acceptLinkedDirectory = false`
 [source,scala]
 ----
 os.exists(wd / "new_folder") ==> false
-os.makeDir.all(wd / "new_folder" / "inner" / "deep")
-os.exists(wd / "new_folder" / "inner" / "deep") ==> true
+os.makeDir.all(wd / "new_folder/inner/deep")
+os.exists(wd / "new_folder/inner/deep") ==> true
 ----
 
 ==== `os.remove`
@@ -996,10 +996,10 @@ os.exists(wd / "File.txt") ==> true
 os.remove(wd / "File.txt")
 os.exists(wd / "File.txt") ==> false
 
-os.exists(wd / "folder1" / "one.txt") ==> true
-os.remove(wd / "folder1" / "one.txt")
+os.exists(wd / "folder1/one.txt") ==> true
+os.remove(wd / "folder1/one.txt")
 os.remove(wd / "folder1")
-os.exists(wd / "folder1" / "one.txt") ==> false
+os.exists(wd / "folder1/one.txt") ==> false
 os.exists(wd / "folder1") ==> false
 ----
 
@@ -1008,17 +1008,17 @@ destination:
 
 [source,scala]
 ----
-os.remove(wd / "misc" / "file-symlink")
-os.exists(wd / "misc" / "file-symlink", followLinks = false) ==> false
+os.remove(wd / "misc/file-symlink")
+os.exists(wd / "misc/file-symlink", followLinks = false) ==> false
 os.exists(wd / "File.txt", followLinks = false) ==> true
 
-os.remove(wd / "misc" / "folder-symlink")
-os.exists(wd / "misc" / "folder-symlink", followLinks = false) ==> false
+os.remove(wd / "misc/folder-symlink")
+os.exists(wd / "misc/folder-symlink", followLinks = false) ==> false
 os.exists(wd / "folder1", followLinks = false) ==> true
-os.exists(wd / "folder1" / "one.txt", followLinks = false) ==> true
+os.exists(wd / "folder1/one.txt", followLinks = false) ==> true
 
-os.remove(wd / "misc" / "broken-symlink")
-os.exists(wd / "misc" / "broken-symlink", followLinks = false) ==> false
+os.remove(wd / "misc/broken-symlink")
+os.exists(wd / "misc/broken-symlink", followLinks = false) ==> false
 ----
 
 If you wish to remove the destination of a symlink, use
@@ -1036,9 +1036,9 @@ removing all it's contents before deleting it.
 
 [source,scala]
 ----
-os.exists(wd / "folder1" / "one.txt") ==> true
+os.exists(wd / "folder1/one.txt") ==> true
 os.remove.all(wd / "folder1")
-os.exists(wd / "folder1" / "one.txt") ==> false
+os.exists(wd / "folder1/one.txt") ==> false
 os.exists(wd / "folder1") ==> false
 ----
 
@@ -1047,17 +1047,17 @@ destination:
 
 [source,scala]
 ----
-os.remove.all(wd / "misc" / "file-symlink")
-os.exists(wd / "misc" / "file-symlink", followLinks = false) ==> false
+os.remove.all(wd / "misc/file-symlink")
+os.exists(wd / "misc/file-symlink", followLinks = false) ==> false
 os.exists(wd / "File.txt", followLinks = false) ==> true
 
-os.remove.all(wd / "misc" / "folder-symlink")
-os.exists(wd / "misc" / "folder-symlink", followLinks = false) ==> false
+os.remove.all(wd / "misc/folder-symlink")
+os.exists(wd / "misc/folder-symlink", followLinks = false) ==> false
 os.exists(wd / "folder1", followLinks = false) ==> true
-os.exists(wd / "folder1" / "one.txt", followLinks = false) ==> true
+os.exists(wd / "folder1/one.txt", followLinks = false) ==> true
 
-os.remove.all(wd / "misc" / "broken-symlink")
-os.exists(wd / "misc" / "broken-symlink", followLinks = false) ==> false
+os.remove.all(wd / "misc/broken-symlink")
+os.exists(wd / "misc/broken-symlink", followLinks = false) ==> false
 ----
 
 If you wish to remove the destination of a symlink, use
@@ -1124,10 +1124,10 @@ Returns the immediate destination of the given symbolic link.
 
 [source,scala]
 ----
-os.readLink(wd / "misc" / "file-symlink") ==> os.up / "File.txt"
-os.readLink(wd / "misc" / "folder-symlink") ==> os.up / "folder1"
-os.readLink(wd / "misc" / "broken-symlink") ==> os.rel / "broken"
-os.readLink(wd / "misc" / "broken-abs-symlink") ==> os.root / "doesnt" / "exist"
+os.readLink(wd / "misc/file-symlink") ==> os.up / "File.txt"
+os.readLink(wd / "misc/folder-symlink") ==> os.up / "folder1"
+os.readLink(wd / "misc/broken-symlink") ==> os.rel / "broken"
+os.readLink(wd / "misc/broken-abs-symlink") ==> os.root / "doesnt/exist"
 ----
 
 Note that symbolic links can be either absolute ``os.Path``s or relative
@@ -1136,10 +1136,10 @@ to automatically resolve relative symbolic links to their absolute destination:
 
 [source,scala]
 ----
-os.readLink.absolute(wd / "misc" / "file-symlink") ==> wd / "File.txt"
-os.readLink.absolute(wd / "misc" / "folder-symlink") ==> wd / "folder1"
-os.readLink.absolute(wd / "misc" / "broken-symlink") ==> wd / "misc" / "broken"
-os.readLink.absolute(wd / "misc" / "broken-abs-symlink") ==> os.root / "doesnt" / "exist"
+os.readLink.absolute(wd / "misc/file-symlink") ==> wd / "File.txt"
+os.readLink.absolute(wd / "misc/folder-symlink") ==> wd / "folder1"
+os.readLink.absolute(wd / "misc/broken-symlink") ==> wd / "misc/broken"
+os.readLink.absolute(wd / "misc/broken-abs-symlink") ==> os.root / "doesnt/exist"
 ----
 
 ==== `os.followLink`
@@ -1155,9 +1155,9 @@ symbolic link in the given path is broken)
 
 [source,scala]
 ----
-os.followLink(wd / "misc" / "file-symlink") ==> Some(wd / "File.txt")
-os.followLink(wd / "misc" / "folder-symlink") ==> Some(wd / "folder1")
-os.followLink(wd / "misc" / "broken-symlink") ==> None
+os.followLink(wd / "misc/file-symlink") ==> Some(wd / "File.txt")
+os.followLink(wd / "misc/folder-symlink") ==> Some(wd / "folder1")
+os.followLink(wd / "misc/broken-symlink") ==> None
 ----
 
 ==== `os.temp`
@@ -1264,9 +1264,9 @@ pass in `followLinks = false` to not do so.
 os.isFile(wd / "File.txt") ==> true
 os.isFile(wd / "folder1") ==> false
 
-os.isFile(wd / "misc" / "file-symlink") ==> true
-os.isFile(wd / "misc" / "folder-symlink") ==> false
-os.isFile(wd / "misc" / "file-symlink", followLinks = false) ==> false
+os.isFile(wd / "misc/file-symlink") ==> true
+os.isFile(wd / "misc/folder-symlink") ==> false
+os.isFile(wd / "misc/file-symlink", followLinks = false) ==> false
 ----
 
 ==== `os.isDir`
@@ -1284,9 +1284,9 @@ pass in `followLinks = false` to not do so.
 os.isDir(wd / "File.txt") ==> false
 os.isDir(wd / "folder1") ==> true
 
-os.isDir(wd / "misc" / "file-symlink") ==> false
-os.isDir(wd / "misc" / "folder-symlink") ==> true
-os.isDir(wd / "misc" / "folder-symlink", followLinks = false) ==> false
+os.isDir(wd / "misc/file-symlink") ==> false
+os.isDir(wd / "misc/folder-symlink") ==> true
+os.isDir(wd / "misc/folder-symlink", followLinks = false) ==> false
 ----
 
 ==== `os.isLink`
@@ -1301,8 +1301,8 @@ default, pass in `followLinks = false` to not do so.
 
 [source,scala]
 ----
-os.isLink(wd / "misc" / "file-symlink") ==> true
-os.isLink(wd / "misc" / "folder-symlink") ==> true
+os.isLink(wd / "misc/file-symlink") ==> true
+os.isLink(wd / "misc/folder-symlink") ==> true
 os.isLink(wd / "folder1") ==> false
 ----
 
@@ -1338,12 +1338,12 @@ os.mtime(wd / "File.txt") ==> 0
 
 os.mtime.set(wd / "File.txt", 90000)
 os.mtime(wd / "File.txt") ==> 90000
-os.mtime(wd / "misc" / "file-symlink") ==> 90000
+os.mtime(wd / "misc/file-symlink") ==> 90000
 
-os.mtime.set(wd / "misc" / "file-symlink", 70000)
+os.mtime.set(wd / "misc/file-symlink", 70000)
 os.mtime(wd / "File.txt") ==> 70000
-os.mtime(wd / "misc" / "file-symlink") ==> 70000
-assert(os.mtime(wd / "misc" / "file-symlink", followLinks = false) != 40000)
+os.mtime(wd / "misc/file-symlink") ==> 70000
+assert(os.mtime(wd / "misc/file-symlink", followLinks = false) != 40000)
 ----
 
 === Filesystem Permissions
@@ -1770,15 +1770,15 @@ Here is an example of use from the Ammonite REPL:
 
 @ os.watch.watch(Seq(os.pwd / "out"), paths => println("paths changed: " + paths.mkString(", ")))
 
-@ os.write(os.pwd / "out" / "i am", "cow")
+@ os.write(os.pwd / "out/i am", "cow")
 
 paths changed: /Users/lihaoyi/Github/Ammonite/out/i am
 
-@ os.move(os.pwd / "out" / "i am", os.pwd / "out" / "hear me")
+@ os.move(os.pwd / "out/i am", os.pwd / "out/hear me")
 
 paths changed: /Users/lihaoyi/Github/Ammonite/out/i am,/Users/lihaoyi/Github/Ammonite/out/hear me
 
-@ os.remove.all(os.pwd / "out" / "version")
+@ os.remove.all(os.pwd / "out/version")
 
 paths changed: /Users/lihaoyi/Github/Ammonite/out/version/log,/Users/lihaoyi/Github/Ammonite/out/version/meta.json,/Users/lihaoyi/Github/Ammonite/out/version
 ----
@@ -1813,13 +1813,16 @@ Absolute paths can be created in a few ways:
 val wd = os.pwd
 
 // A path nested inside `wd`
-wd / "folder" / "file"
+wd / "folder/file"
+
+// The RHS of `/` can have multiple segments if-and-only-if it is a literal string
+wd / "folder/file"
 
 // A path starting from the root
-os.root / "folder" / "file"
+os.root / "folder/file"
 
 // A path with spaces or other special characters
-wd / "My Folder" / "My File.txt"
+wd / "My Folder/My File.txt"
 
 // Up one level from the wd
 wd / os.up
@@ -1864,15 +1867,16 @@ before the relative path is applied. They can be created in the following ways:
 [source,scala]
 ----
 // The path "folder/file"
-val rel1 = os.rel / "folder" / "file"
-val rel2 = os.rel / "folder" / "file"
+val rel1 = os.rel / "folder/file"
+// RHS of `/` can have multiple segments if-and-only-if it is a literal string
+val rel2 = os.rel / "folder/file"
 
 // The path "file"
 val rel3 = os.rel / "file"
 
 // The relative difference between two paths
-val target = os.pwd / "target" / "file"
-assert((target.relativeTo(os.pwd)) == os.rel / "target" / "file")
+val target = os.pwd / "target/file"
+assert((target.relativeTo(os.pwd)) == os.rel / "target/file")
 
 // `up`s get resolved automatically
 val minus = os.pwd.relativeTo(target)
@@ -1885,17 +1889,17 @@ combined with absolute paths in order to create new absolute paths. e.g.
 
 [source,scala]
 ----
-val target = os.pwd / "target" / "file"
+val target = os.pwd / "target/file"
 val difference = target.relativeTo(os.pwd)
-val newBase = os.root / "code" / "server"
-assert(newBase / difference == os.root / "code" / "server" / "target" / "file")
+val newBase = os.root / "code/server"
+assert(newBase / difference == os.root / "code/server/target/file")
 ----
 
 `os.up` is a relative path that comes in-built:
 
 [source,scala]
 ----
-val target = os.root / "target" / "file"
+val target = os.root / "target/file"
 assert(target / os.up == os.root / "target")
 ----
 
@@ -1904,10 +1908,10 @@ canonical manner:
 
 [source,scala]
 ----
-assert((os.root / "folder" / "file" / os.up).toString == "/folder")
+assert((os.root / "folder/file" / os.up).toString == "/folder")
 // not "/folder/file/.."
 
-assert((os.rel / "folder" / "file" / os.up).toString == "folder")
+assert((os.rel / "folder/file" / os.up).toString == "folder")
 // not "folder/file/.."
 ----
 
@@ -1929,15 +1933,16 @@ They can be created in the following ways:
 [source,scala]
 ----
 // The path "folder/file"
-val sub1 = os.sub / "folder" / "file"
-val sub2 = os.sub / "folder" / "file"
+val sub1 = os.sub / "folder/file"
+// RHS of `/` can have multiple segments if-and-only-if it is a literal string
+val sub2 = os.sub / "folder/file"
 
 // The relative difference between two paths
-val target = os.pwd / "out" / "scratch" / "file"
-assert((target subRelativeTo os.pwd) == os.sub / "out" / "scratch" / "file")
+val target = os.pwd / "out/scratch/file"
+assert((target subRelativeTo os.pwd) == os.sub / "out/scratch/file")
 
 // Converting os.RelPath to os.SubPath
-val rel3 = os.rel / "folder" / "file"
+val rel3 = os.rel / "folder/file"
 val sub3 = rel3.asSubPath
 ----
 
@@ -1949,10 +1954,10 @@ du to accidentally accessing paths outside the destination folder.
 
 [source,scala]
 ----
-val target = os.pwd / "target" / "file"
+val target = os.pwd / "target/file"
 val difference = target.relativeTo(os.pwd)
-val newBase = os.root / "code" / "server"
-assert(newBase / difference == os.root / "code" / "server" / "target" / "file")
+val newBase = os.root / "code/server"
+assert(newBase / difference == os.root / "code/server/target/file")
 ----
 
 Attempting to construct an `os.SubPath` with `..` segments results in an
@@ -1960,7 +1965,7 @@ exception being thrown:
 
 [source,scala]
 ----
-val target = os.pwd / "out" / "scratch" /
+val target = os.pwd / "out/scratch" /
 
 // `up`s are not allowed in sub paths
 intercept[Exception](os.pwd subRelativeTo target)
@@ -2000,10 +2005,10 @@ val relStr = "hello/cow/world/.."
 val absStr = "/hello/world"
 
 assert(
-  RelPath(relStr) == "hello" / "cow",
+  RelPath(relStr) == "hello/cow",
   // Path(...) also allows paths starting with ~,
   // which is expanded to become your home directory
-  Path(absStr) == os.root / "hello" / "world"
+  Path(absStr) == os.root / "hello/world"
 )
 
 // You can also pass in java.io.File and java.nio.file.Path
@@ -2012,9 +2017,9 @@ val relIoFile = new java.io.File(relStr)
 val absNioFile = java.nio.file.Paths.get(absStr)
 
 assert(
-  RelPath(relIoFile) ==  "hello" / "cow",
-  Path(absNioFile) == os.root / "hello" / "world",
-  Path(relIoFile, root / "base") == os.root / "base" / "hello" / "cow"
+  RelPath(relIoFile) ==  "hello/cow",
+  Path(absNioFile) == os.root / "hello/world",
+  Path(relIoFile, root / "base") == os.root / "base/hello/cow"
 )
 ----
 
@@ -2048,8 +2053,8 @@ parse it :
 val relStr = "hello/cow/world/.."
 val absStr = "/hello/world"
 assert(
-  FilePath(relStr) == "hello" / "cow",
-  FilePath(absStr) == os.root / "hello" / "world"
+  FilePath(relStr) == "hello/cow",
+  FilePath(absStr) == os.root / "hello/world"
 )
 ----
 
@@ -2067,9 +2072,9 @@ val relStr = "hello/cow/world/.."
 val absStr = "/hello/world"
 val basePath: FilePath = FilePath(relStr)
 assert(
-  os.Path(relStr,   os.root / "base") == os.root / "base" / "hello" / "cow",
-  os.Path(absStr,   os.root / "base") == os.root / "hello" / "world",
-  os.Path(basePath, os.root / "base") == os.root / "base" / "hello" / "cow",
+  os.Path(relStr,   os.root / "base") == os.root / "base/hello/cow",
+  os.Path(absStr,   os.root / "base") == os.root / "hello/world",
+  os.Path(basePath, os.root / "base") == os.root / "base/hello/cow",
   os.Path(".", os.pwd).last != ""
 )
 ----
@@ -2096,7 +2101,7 @@ If not specified, the default root will be used (usually, C on Windows, / on Uni
 
 [source,scala]
 ----
-val root = os.root('C:\') / "Users" / "me"
+val root = os.root('C:\') / "Users/me"
 assert(root == os.Path("C:\Users\me"))
 ----
 
@@ -2129,7 +2134,7 @@ default, the path used to load resources is absolute, using the
 
 [source,scala]
 ----
-val contents = os.read(os.resource / "test" / "ammonite" / "ops" / "folder" / "file.txt")
+val contents = os.read(os.resource / "test/ammonite/ops/folder/file.txt")
 assert(contents.contains("file contents lols"))
 ----
 
@@ -2138,7 +2143,7 @@ You can also pass in a classloader explicitly to the resource call:
 [source,scala]
 ----
 val cl = getClass.getClassLoader
-val contents2 = os.read(os.resource(cl)/ "test" / "ammonite" / "ops" / "folder" / "file.txt")
+val contents2 = os.read(os.resource(cl)/ "test/ammonite/ops/folder/file.txt")
 assert(contents2.contains("file contents lols"))
 ----
 
@@ -2149,10 +2154,10 @@ current class.
 [source,scala]
 ----
 val cls = classOf[test.os.Testing]
-val contents = os.read(os.resource(cls) / "folder" / "file.txt")
+val contents = os.read(os.resource(cls) / "folder/file.txt")
 assert(contents.contains("file contents lols"))
 
-val contents2 = os.read(os.resource(getClass) / "folder" / "file.txt")
+val contents2 = os.read(os.resource(getClass) / "folder/file.txt")
 assert(contents2.contains("file contents lols"))
 ----
 
@@ -2247,8 +2252,8 @@ string, int or set representations of the `os.PermSet` via:
 
 == Changelog
 
-[#main]
-=== main
+[#0-10-7]
+=== 0.10.7
 
 * Allow multi-segment paths segments for literals https://github.com/com-lihaoyi/os-lib/pull/297
 

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -1831,6 +1831,16 @@ wd / os.up
 wd / os.up / os.up
 ----
 
+When constructing `os.Path`s, the right-hand-side of the `/` operator must be either a non-literal
+a string expression containing a single path segment or a literal string containing one-or-more
+path segments. If a non-literal string expression on the RHS contains multiple segments, you need
+to wrap the RHS in an explicit `os.RelPath(...)` or `os.SubPath(...)` constructor to tell OS-Lib
+how to interpret it. The single-segment limitation is intended to avoid the developer accidentally
+introducing https://en.wikipedia.org/wiki/Directory_traversal_attack[Directory Traversal Attacks]
+or other related bugs when naively constructing paths out of dynamic and potentially untrusted
+inputs, which is not an issue for literal string since the string value is directly written in
+the source code and immediately visible.
+
 `os.pwd` can be modified in certain scopes via the `os.dynamicPwd` dynamic variable, but
 best practice is not to change it. Instead simply define a new path, e.g.
 
@@ -1948,8 +1958,8 @@ val sub3 = rel3.asSubPath
 
 ``os.SubPath``s are useful for representing paths within a particular
 folder or directory. You can combine them with absolute ``os.Path``s to
-resolve paths within them, without needing to worry about https://en.wikipedia.org/wiki/Directory_traversal_attack[Directory
-Traversal Attacks]
+resolve paths within them, without needing to worry about
+https://en.wikipedia.org/wiki/Directory_traversal_attack[Directory Traversal Attacks]
 du to accidentally accessing paths outside the destination folder.
 
 [source,scala]

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -2262,8 +2262,8 @@ string, int or set representations of the `os.PermSet` via:
 
 == Changelog
 
-[#0-10-7]
-=== 0.10.7
+[#main]
+=== main
 
 * Allow multi-segment paths segments for literals https://github.com/com-lihaoyi/os-lib/pull/297
 

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -1812,8 +1812,8 @@ Absolute paths can be created in a few ways:
 // from the pwd) is called `wd`
 val wd = os.pwd
 
-// A path nested inside `wd`
-wd / "folder/file"
+// A path nested inside `wd` in multiple segments
+wd / "folder" / "file"
 
 // The RHS of `/` can have multiple segments if-and-only-if it is a literal string
 wd / "folder/file"
@@ -1866,8 +1866,8 @@ before the relative path is applied. They can be created in the following ways:
 
 [source,scala]
 ----
-// The path "folder/file"
-val rel1 = os.rel / "folder/file"
+// The path "folder/file" in multiple segments
+val rel1 = os.rel / "folder" / "file"
 // RHS of `/` can have multiple segments if-and-only-if it is a literal string
 val rel2 = os.rel / "folder/file"
 
@@ -1932,8 +1932,8 @@ They can be created in the following ways:
 
 [source,scala]
 ----
-// The path "folder/file"
-val sub1 = os.sub / "folder/file"
+// The path "folder/file" in multiple segments
+val sub1 = os.sub / "folder" / "file"
 // RHS of `/` can have multiple segments if-and-only-if it is a literal string
 val sub2 = os.sub / "folder/file"
 

--- a/os/test/src-jvm/ExampleTests.scala
+++ b/os/test/src-jvm/ExampleTests.scala
@@ -9,7 +9,7 @@ object ExampleTests extends TestSuite {
     test("splash") - TestUtil.prep { wd =>
       if (Unix()) {
         // Make sure working directory exists and is empty
-        val wd = os.pwd / "out" / "splash"
+        val wd = os.pwd / "out/splash"
         os.remove.all(wd)
         os.makeDir.all(wd)
 
@@ -95,8 +95,8 @@ object ExampleTests extends TestSuite {
 
       // ignore multiline (second file) because its size varies
       largestThree.filterNot(_._2.last == "Multi Line.txt") ==> Seq(
-        (711, wd / "misc" / "binary.png"),
-        (22, wd / "folder1" / "one.txt")
+        (711, wd / "misc/binary.png"),
+        (22, wd / "folder1/one.txt")
       )
     }
 
@@ -115,9 +115,9 @@ object ExampleTests extends TestSuite {
     }
     test("comparison") {
 
-      os.remove.all(os.pwd / "out" / "scratch" / "folder" / "thing" / "file")
+      os.remove.all(os.pwd / "out/scratch/folder/thing/file")
       os.write(
-        os.pwd / "out" / "scratch" / "folder" / "thing" / "file",
+        os.pwd / "out/scratch/folder/thing/file",
         "Hello!",
         createFolders = true
       )
@@ -135,16 +135,16 @@ object ExampleTests extends TestSuite {
       }
       removeAll("out/scratch/folder/thing")
 
-      assert(os.list(os.pwd / "out" / "scratch" / "folder").toSeq == Nil)
+      assert(os.list(os.pwd / "out/scratch/folder").toSeq == Nil)
 
       os.write(
-        os.pwd / "out" / "scratch" / "folder" / "thing" / "file",
+        os.pwd / "out/scratch/folder/thing/file",
         "Hello!",
         createFolders = true
       )
 
-      os.remove.all(os.pwd / "out" / "scratch" / "folder" / "thing")
-      assert(os.list(os.pwd / "out" / "scratch" / "folder").toSeq == Nil)
+      os.remove.all(os.pwd / "out/scratch/folder/thing")
+      assert(os.list(os.pwd / "out/scratch/folder").toSeq == Nil)
     }
 
     test("constructingPaths") {
@@ -155,13 +155,13 @@ object ExampleTests extends TestSuite {
       val wd = os.pwd
 
       // A path nested inside `wd`
-      wd / "folder" / "file"
+      wd / "folder/file"
 
       // A path starting from the root
-      os.root / "folder" / "file"
+      os.root / "folder/file"
 
       // A path with spaces or other special characters
-      wd / "My Folder" / "My File.txt"
+      wd / "My Folder/My File.txt"
 
       // Up one level from the wd
       wd / os.up
@@ -171,17 +171,17 @@ object ExampleTests extends TestSuite {
     }
     test("newPath") {
 
-      val target = os.pwd / "out" / "scratch"
+      val target = os.pwd / "out/scratch"
     }
     test("relPaths") {
 
       // The path "folder/file"
-      val rel1 = os.rel / "folder" / "file"
-      val rel2 = os.rel / "folder" / "file"
+      val rel1 = os.rel / "folder/file"
+      val rel2 = os.rel / "folder/file"
 
       // The relative difference between two paths
-      val target = os.pwd / "out" / "scratch" / "file"
-      assert((target relativeTo os.pwd) == os.rel / "out" / "scratch" / "file")
+      val target = os.pwd / "out/scratch/file"
+      assert((target relativeTo os.pwd) == os.rel / "out/scratch/file")
 
       // `up`s get resolved automatically
       val minus = os.pwd relativeTo target
@@ -195,15 +195,15 @@ object ExampleTests extends TestSuite {
     test("subPaths") {
 
       // The path "folder/file"
-      val sub1 = os.sub / "folder" / "file"
-      val sub2 = os.sub / "folder" / "file"
+      val sub1 = os.sub / "folder/file"
+      val sub2 = os.sub / "folder/file"
 
       // The relative difference between two paths
-      val target = os.pwd / "out" / "scratch" / "file"
-      assert((target subRelativeTo os.pwd) == os.sub / "out" / "scratch" / "file")
+      val target = os.pwd / "out/scratch/file"
+      assert((target subRelativeTo os.pwd) == os.sub / "out/scratch/file")
 
       // Converting os.RelPath to os.SubPath
-      val rel3 = os.rel / "folder" / "file"
+      val rel3 = os.rel / "folder/file"
       val sub3 = rel3.asSubPath
 
       // `up`s are not allowed in sub paths
@@ -211,50 +211,50 @@ object ExampleTests extends TestSuite {
     }
     test("relSubPathEquality") {
       assert(
-        (os.sub / "hello" / "world") == (os.rel / "hello" / "world"),
+        (os.sub / "hello/world") == (os.rel / "hello/world"),
         os.sub == os.rel
       )
     }
     test("relPathCombine") {
-      val target = os.pwd / "out" / "scratch" / "file"
+      val target = os.pwd / "out/scratch/file"
       val rel = target relativeTo os.pwd
-      val newBase = os.root / "code" / "server"
-      assert(newBase / rel == os.root / "code" / "server" / "out" / "scratch" / "file")
+      val newBase = os.root / "code/server"
+      assert(newBase / rel == os.root / "code/server/out/scratch/file")
     }
     test("subPathCombine") {
-      val target = os.pwd / "out" / "scratch" / "file"
+      val target = os.pwd / "out/scratch/file"
       val sub = target subRelativeTo os.pwd
-      val newBase = os.root / "code" / "server"
+      val newBase = os.root / "code/server"
       assert(
-        newBase / sub == os.root / "code" / "server" / "out" / "scratch" / "file",
-        sub / sub == os.sub / "out" / "scratch" / "file" / "out" / "scratch" / "file"
+        newBase / sub == os.root / "code/server/out/scratch/file",
+        sub / sub == os.sub / "out/scratch/file/out/scratch/file"
       )
     }
     test("pathUp") {
-      val target = os.root / "out" / "scratch" / "file"
-      assert(target / os.up == os.root / "out" / "scratch")
+      val target = os.root / "out/scratch/file"
+      assert(target / os.up == os.root / "out/scratch")
     }
     test("relPathUp") {
-      val target = os.rel / "out" / "scratch" / "file"
-      assert(target / os.up == os.rel / "out" / "scratch")
+      val target = os.rel / "out/scratch/file"
+      assert(target / os.up == os.rel / "out/scratch")
     }
     test("relPathUp") {
-      val target = os.sub / "out" / "scratch" / "file"
-      assert(target / os.up == os.sub / "out" / "scratch")
+      val target = os.sub / "out/scratch/file"
+      assert(target / os.up == os.sub / "out/scratch")
     }
     test("canonical") {
       if (Unix()) {
 
-        assert((os.root / "folder" / "file" / os.up).toString == "/folder")
+        assert((os.root / "folder/file" / os.up).toString == "/folder")
         // not "/folder/file/.."
 
-        assert((os.rel / "folder" / "file" / os.up).toString == "folder")
+        assert((os.rel / "folder/file" / os.up).toString == "folder")
         // not "folder/file/.."
       }
     }
     test("findWc") {
 
-      val wd = os.pwd / "os" / "test" / "resources" / "test"
+      val wd = os.pwd / "os/test/resources/test"
 
       // find . -name '*.txt' | xargs wc -l
       val lines = os.walk(wd)

--- a/os/test/src-jvm/OpTestsJvmOnly.scala
+++ b/os/test/src-jvm/OpTestsJvmOnly.scala
@@ -10,48 +10,48 @@ import java.nio.charset.Charset
 object OpTestsJvmOnly extends TestSuite {
 
   val tests = Tests {
-    val res = os.pwd / "os" / "test" / "resources" / "test"
-    val testFolder = os.pwd / "out" / "scratch" / "test"
+    val res = os.pwd / "os/test/resources/test"
+    val testFolder = os.pwd / "out/scratch/test"
     test("lsRecPermissions") {
       if (Unix()) {
-        assert(os.walk(os.root / "var" / "run").nonEmpty)
+        assert(os.walk(os.root / "var/run").nonEmpty)
       }
     }
     test("readResource") {
       test("positive") {
         test("absolute") {
-          val contents = os.read(os.resource / "test" / "os" / "folder" / "file.txt")
+          val contents = os.read(os.resource / "test/os/folder/file.txt")
           assert(contents.contains("file contents lols"))
 
           val cl = getClass.getClassLoader
-          val contents2 = os.read(os.resource(cl) / "test" / "os" / "folder" / "file.txt")
+          val contents2 = os.read(os.resource(cl) / "test/os/folder/file.txt")
           assert(contents2.contains("file contents lols"))
         }
 
         test("relative") {
           val cls = classOf[_root_.test.os.Testing]
-          val contents = os.read(os.resource(cls) / "folder" / "file.txt")
+          val contents = os.read(os.resource(cls) / "folder/file.txt")
           assert(contents.contains("file contents lols"))
 
-          val contents2 = os.read(os.resource(getClass) / "folder" / "file.txt")
+          val contents2 = os.read(os.resource(getClass) / "folder/file.txt")
           assert(contents2.contains("file contents lols"))
         }
       }
       test("negative") {
         test - intercept[os.ResourceNotFoundException] {
-          os.read(os.resource / "folder" / "file.txt")
+          os.read(os.resource / "folder/file.txt")
         }
 
         test - intercept[os.ResourceNotFoundException] {
           os.read(
-            os.resource(classOf[_root_.test.os.Testing]) / "test" / "os" / "folder" / "file.txt"
+            os.resource(classOf[_root_.test.os.Testing]) / "test/os/folder/file.txt"
           )
         }
         test - intercept[os.ResourceNotFoundException] {
-          os.read(os.resource(getClass) / "test" / "os" / "folder" / "file.txt")
+          os.read(os.resource(getClass) / "test/os/folder/file.txt")
         }
         test - intercept[os.ResourceNotFoundException] {
-          os.read(os.resource(getClass.getClassLoader) / "folder" / "file.txt")
+          os.read(os.resource(getClass.getClassLoader) / "folder/file.txt")
         }
       }
     }
@@ -74,16 +74,16 @@ object OpTestsJvmOnly extends TestSuite {
     // Not sure why this doesn't work on native
     test("redirectSubprocessInheritedOutput") {
       if (Unix()) { // relies on bash scripts that don't run on windows
-        val scriptFolder = os.pwd / "os" / "test" / "resources" / "test"
+        val scriptFolder = os.pwd / "os/test/resources/test"
         val lines = collection.mutable.Buffer.empty[String]
         os.Inherit.out.withValue(os.ProcessOutput.Readlines(lines.append(_))) {
           // Redirected
-          os.proc(scriptFolder / "misc" / "echo_with_wd", "HELLO\nWorld").call(
+          os.proc(scriptFolder / "misc/echo_with_wd", "HELLO\nWorld").call(
             cwd = os.root / "usr",
             stdout = os.Inherit
           )
           // Not Redirected
-          os.proc(scriptFolder / "misc" / "echo_with_wd", "hello\nWORLD").call(
+          os.proc(scriptFolder / "misc/echo_with_wd", "hello\nWORLD").call(
             cwd = os.root / "usr",
             stdout = os.InheritRaw
           )

--- a/os/test/src-jvm/PathTestsCustomFilesystem.scala
+++ b/os/test/src-jvm/PathTestsCustomFilesystem.scala
@@ -24,7 +24,7 @@ object PathTestsCustomFilesystem extends TestSuite {
     val p = os.root("/", fs)
     try {
       os.makeDir(p / "test")
-      os.makeDir(p / "test" / "dir")
+      os.makeDir(p / "test/dir")
       f(fs)
     } finally {
       cleanUpFs(fs, fsUri)
@@ -40,7 +40,7 @@ object PathTestsCustomFilesystem extends TestSuite {
     test("customFilesystem") {
       test("createPath") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           assert(p.root == "/")
           assert(p.fileSystem == fileSystem)
         }
@@ -55,7 +55,7 @@ object PathTestsCustomFilesystem extends TestSuite {
       }
       test("removeDir") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir" / "dir2"
+          val p = os.root("/", fileSystem) / "test/dir/dir2"
           os.makeDir.all(p)
           assert(os.exists(p))
           os.remove.all(p)
@@ -64,7 +64,7 @@ object PathTestsCustomFilesystem extends TestSuite {
       }
       test("failTemp") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           intercept[UnsupportedOperationException] {
             os.temp.dir(dir = p)
           }
@@ -72,7 +72,7 @@ object PathTestsCustomFilesystem extends TestSuite {
       }
       test("failProcCall") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           intercept[UnsupportedOperationException] {
             os.proc("echo", "hello").call(cwd = p)
           }
@@ -80,30 +80,30 @@ object PathTestsCustomFilesystem extends TestSuite {
       }
       test("up") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           assert((p / os.up) == os.root("/", fileSystem) / "test")
         }
       }
       test("withRelPath") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           val rel = os.rel / os.up / "file.txt"
-          assert((p / rel) == os.root("/", fileSystem) / "test" / "file.txt")
+          assert((p / rel) == os.root("/", fileSystem) / "test/file.txt")
         }
       }
       test("withSubPath") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           val sub = os.sub / "file.txt"
-          assert((p / sub) == os.root("/", fileSystem) / "test" / "dir" / "file.txt")
+          assert((p / sub) == os.root("/", fileSystem) / "test/dir/file.txt")
         }
       }
       test("differentFsCompare") {
         withCustomFs { fs1 =>
           withCustomFs(
             { fs2 =>
-              val p1 = os.root("/", fs1) / "test" / "dir"
-              val p2 = os.root("/", fs2) / "test" / "dir"
+              val p1 = os.root("/", fs1) / "test/dir"
+              val p2 = os.root("/", fs2) / "test/dir"
               assert(p1 != p2)
             },
             fsUri = customFsUri("bar.jar")
@@ -114,8 +114,8 @@ object PathTestsCustomFilesystem extends TestSuite {
         withCustomFs { fs1 =>
           withCustomFs(
             { fs2 =>
-              val p1 = os.root("/", fs1) / "test" / "dir"
-              val p2 = os.root("/", fs2) / "test" / "dir"
+              val p1 = os.root("/", fs1) / "test/dir"
+              val p2 = os.root("/", fs2) / "test/dir"
               intercept[IllegalArgumentException] {
                 p1.relativeTo(p2)
               }
@@ -128,8 +128,8 @@ object PathTestsCustomFilesystem extends TestSuite {
         withCustomFs { fs1 =>
           withCustomFs(
             { fs2 =>
-              val p1 = os.root("/", fs1) / "test" / "dir"
-              val p2 = os.root("/", fs2) / "test" / "dir"
+              val p1 = os.root("/", fs1) / "test/dir"
+              val p2 = os.root("/", fs2) / "test/dir"
               intercept[IllegalArgumentException] {
                 p1.subRelativeTo(p2)
               }
@@ -145,14 +145,14 @@ object PathTestsCustomFilesystem extends TestSuite {
     test("customFilesystem") {
       test("writeAndRead") {
         withCustomFs { fileSystem =>
-          val p = root("/", fileSystem) / "test" / "dir"
+          val p = root("/", fileSystem) / "test/dir"
           os.write(p / "file.txt", "Hello")
           assert(os.read(p / "file.txt") == "Hello")
         }
       }
       test("writeOver") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           os.write(p / "file.txt", "Hello World")
           os.write.over(p / "file.txt", "Hello World2")
           assert(os.read(p / "file.txt") == "Hello World2")
@@ -160,7 +160,7 @@ object PathTestsCustomFilesystem extends TestSuite {
       }
       test("move") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           os.write(p / "file.txt", "Hello World")
           os.move(p / "file.txt", p / "file2.txt")
           assert(os.read(p / "file2.txt") == "Hello World")
@@ -169,7 +169,7 @@ object PathTestsCustomFilesystem extends TestSuite {
       }
       test("copy") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           os.write(p / "file.txt", "Hello World")
           os.copy(p / "file.txt", p / "file2.txt")
           assert(os.read(p / "file2.txt") == "Hello World")
@@ -179,9 +179,9 @@ object PathTestsCustomFilesystem extends TestSuite {
       test("copyAndMergeToRootDirectoryWithCreateFolders") {
         withCustomFs { fileSystem =>
           val root = os.root("/", fileSystem)
-          val file = root / "test" / "dir" / "file.txt"
+          val file = root / "test/dir/file.txt"
           os.write(file, "Hello World")
-          os.copy(root / "test" / "dir", root, createFolders = true, mergeFolders = true)
+          os.copy(root / "test/dir", root, createFolders = true, mergeFolders = true)
           assert(os.read(root / "file.txt") == "Hello World")
           assert(os.exists(root / "file.txt"))
         }
@@ -191,14 +191,14 @@ object PathTestsCustomFilesystem extends TestSuite {
           val root = os.root("/", fileSystem)
           // This should fail. Just test that it doesn't throw PathError.AbsolutePathOutsideRoot.
           intercept[FileAlreadyExistsException] {
-            os.move(root / "test" / "dir", root, createFolders = true)
+            os.move(root / "test/dir", root, createFolders = true)
           }
         }
       }
       test("copyMatchingAndMergeToRootDirectory") {
         withCustomFs { fileSystem =>
           val root = os.root("/", fileSystem)
-          val file = root / "test" / "dir" / "file.txt"
+          val file = root / "test/dir/file.txt"
           os.write(file, "Hello World")
           os.list(root / "test").collect(os.copy.matching(mergeFolders = true) {
             case p / "test" / _ => p
@@ -221,7 +221,7 @@ object PathTestsCustomFilesystem extends TestSuite {
       }
       test("remove") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           os.write(p / "file.txt", "Hello World")
           assert(os.exists(p / "file.txt"))
           os.remove(p / "file.txt")
@@ -230,7 +230,7 @@ object PathTestsCustomFilesystem extends TestSuite {
       }
       test("removeAll") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           os.write(p / "file.txt", "Hello World")
           os.write(p / "file2.txt", "Hello World")
           os.remove.all(p)
@@ -240,7 +240,7 @@ object PathTestsCustomFilesystem extends TestSuite {
       }
       test("failSymlink") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           os.write(p / "file.txt", "Hello World")
           intercept[UnsupportedOperationException] {
             os.symlink(p / "link", p / "file.txt")
@@ -249,12 +249,12 @@ object PathTestsCustomFilesystem extends TestSuite {
       }
       test("walk") {
         withCustomFs { fileSystem =>
-          val p = os.root("/", fileSystem) / "test" / "dir"
+          val p = os.root("/", fileSystem) / "test/dir"
           os.write(p / "file.txt", "Hello World")
           os.write(p / "file2.txt", "Hello World")
           os.write(p / "file3.txt", "Hello World")
           os.makeDir(p / "dir2")
-          os.write(p / "dir2" / "file.txt", "Hello World")
+          os.write(p / "dir2/file.txt", "Hello World")
           assert(os.walk(p).map(_.relativeTo(p)).toSet ==
             Set(
               RelPath("file.txt"),

--- a/os/test/src-jvm/ProcessPipelineTests.scala
+++ b/os/test/src-jvm/ProcessPipelineTests.scala
@@ -9,7 +9,7 @@ import TestUtil.prep
 import scala.util.Try
 
 object ProcessPipelineTests extends TestSuite {
-  val scriptFolder = pwd / "os" / "test" / "resources" / "scripts"
+  val scriptFolder = pwd / "os/test/resources/scripts"
 
   lazy val scalaHome = sys.env("SCALA_HOME")
 

--- a/os/test/src/FilesystemMetadataTests.scala
+++ b/os/test/src/FilesystemMetadataTests.scala
@@ -28,9 +28,9 @@ object FilesystemMetadataTests extends TestSuite {
         os.isFile(wd / "File.txt") ==> true
         os.isFile(wd / "folder1") ==> false
 
-        os.isFile(wd / "misc" / "file-symlink") ==> true
-        os.isFile(wd / "misc" / "folder-symlink") ==> false
-        os.isFile(wd / "misc" / "file-symlink", followLinks = false) ==> false
+        os.isFile(wd / "misc/file-symlink") ==> true
+        os.isFile(wd / "misc/folder-symlink") ==> false
+        os.isFile(wd / "misc/file-symlink", followLinks = false) ==> false
       }
     }
     test("isDir") {
@@ -38,15 +38,15 @@ object FilesystemMetadataTests extends TestSuite {
         os.isDir(wd / "File.txt") ==> false
         os.isDir(wd / "folder1") ==> true
 
-        os.isDir(wd / "misc" / "file-symlink") ==> false
-        os.isDir(wd / "misc" / "folder-symlink") ==> true
-        os.isDir(wd / "misc" / "folder-symlink", followLinks = false) ==> false
+        os.isDir(wd / "misc/file-symlink") ==> false
+        os.isDir(wd / "misc/folder-symlink") ==> true
+        os.isDir(wd / "misc/folder-symlink", followLinks = false) ==> false
       }
     }
     test("isLink") {
       test - prep { wd =>
-        os.isLink(wd / "misc" / "file-symlink") ==> true
-        os.isLink(wd / "misc" / "folder-symlink") ==> true
+        os.isLink(wd / "misc/file-symlink") ==> true
+        os.isLink(wd / "misc/folder-symlink") ==> true
         os.isLink(wd / "folder1") ==> false
       }
     }
@@ -63,12 +63,12 @@ object FilesystemMetadataTests extends TestSuite {
 
         os.mtime.set(wd / "File.txt", 90000)
         os.mtime(wd / "File.txt") ==> 90000
-        os.mtime(wd / "misc" / "file-symlink") ==> 90000
+        os.mtime(wd / "misc/file-symlink") ==> 90000
 
-        os.mtime.set(wd / "misc" / "file-symlink", 70000)
+        os.mtime.set(wd / "misc/file-symlink", 70000)
         os.mtime(wd / "File.txt") ==> 70000
-        os.mtime(wd / "misc" / "file-symlink") ==> 70000
-        assert(os.mtime(wd / "misc" / "file-symlink", followLinks = false) != 40000)
+        os.mtime(wd / "misc/file-symlink") ==> 70000
+        assert(os.mtime(wd / "misc/file-symlink", followLinks = false) != 40000)
 
       }
     }

--- a/os/test/src/ListingWalkingTests.scala
+++ b/os/test/src/ListingWalkingTests.scala
@@ -7,14 +7,14 @@ object ListingWalkingTests extends TestSuite {
   def tests = Tests {
     test("list") {
       test - prep { wd =>
-        os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
+        os.list(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
         os.list(wd / "folder2") ==> Seq(
-          wd / "folder2" / "nestedA",
-          wd / "folder2" / "nestedB"
+          wd / "folder2/nestedA",
+          wd / "folder2/nestedB"
         )
 
-        os.list(wd / "misc" / "folder-symlink") ==> Seq(
-          wd / "misc" / "folder-symlink" / "one.txt"
+        os.list(wd / "misc/folder-symlink") ==> Seq(
+          wd / "misc/folder-symlink/one.txt"
         )
       }
       test("stream") {
@@ -30,39 +30,39 @@ object ListingWalkingTests extends TestSuite {
     }
     test("walk") {
       test - prep { wd =>
-        os.walk(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
+        os.walk(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
 
         os.walk(wd / "folder1", includeTarget = true) ==> Seq(
           wd / "folder1",
-          wd / "folder1" / "one.txt"
+          wd / "folder1/one.txt"
         )
 
         os.walk(wd / "folder2").toSet ==> Set(
-          wd / "folder2" / "nestedA",
-          wd / "folder2" / "nestedA" / "a.txt",
-          wd / "folder2" / "nestedB",
-          wd / "folder2" / "nestedB" / "b.txt"
+          wd / "folder2/nestedA",
+          wd / "folder2/nestedA/a.txt",
+          wd / "folder2/nestedB",
+          wd / "folder2/nestedB/b.txt"
         )
 
         os.walk(wd / "folder2", preOrder = false).toSet ==> Set(
-          wd / "folder2" / "nestedA" / "a.txt",
-          wd / "folder2" / "nestedA",
-          wd / "folder2" / "nestedB" / "b.txt",
-          wd / "folder2" / "nestedB"
+          wd / "folder2/nestedA/a.txt",
+          wd / "folder2/nestedA",
+          wd / "folder2/nestedB/b.txt",
+          wd / "folder2/nestedB"
         )
 
         os.walk(wd / "folder2", maxDepth = 1).toSet ==> Set(
-          wd / "folder2" / "nestedA",
-          wd / "folder2" / "nestedB"
+          wd / "folder2/nestedA",
+          wd / "folder2/nestedB"
         )
 
         os.walk(wd / "folder2", skip = _.last == "nestedA").toSet ==> Set(
-          wd / "folder2" / "nestedB",
-          wd / "folder2" / "nestedB" / "b.txt"
+          wd / "folder2/nestedB",
+          wd / "folder2/nestedB/b.txt"
         )
 
-        os.walk(wd / "misc" / "folder-symlink").toSet ==> Set(
-          wd / "misc" / "folder-symlink" / "one.txt"
+        os.walk(wd / "misc/folder-symlink").toSet ==> Set(
+          wd / "misc/folder-symlink/one.txt"
         )
       }
       test("attrs") {
@@ -73,11 +73,11 @@ object ListingWalkingTests extends TestSuite {
               .collect { case (p, attrs) if attrs.isFile => p }
 
             filesSortedBySize ==> Seq(
-              wd / "misc" / "echo",
-              wd / "misc" / "file-symlink",
-              wd / "misc" / "echo_with_wd",
-              wd / "misc" / "folder-symlink" / "one.txt",
-              wd / "misc" / "binary.png"
+              wd / "misc/echo",
+              wd / "misc/file-symlink",
+              wd / "misc/echo_with_wd",
+              wd / "misc/folder-symlink/one.txt",
+              wd / "misc/binary.png"
             )
           }
         }

--- a/os/test/src/ManipulatingFilesFoldersTests.scala
+++ b/os/test/src/ManipulatingFilesFoldersTests.scala
@@ -11,21 +11,21 @@ object ManipulatingFilesFoldersTests extends TestSuite {
         os.exists(wd / "folder1") ==> true
         os.exists(wd / "doesnt-exist") ==> false
 
-        os.exists(wd / "misc" / "file-symlink") ==> true
-        os.exists(wd / "misc" / "folder-symlink") ==> true
-        os.exists(wd / "misc" / "broken-symlink") ==> false
-        os.exists(wd / "misc" / "broken-symlink", followLinks = false) ==> true
+        os.exists(wd / "misc/file-symlink") ==> true
+        os.exists(wd / "misc/folder-symlink") ==> true
+        os.exists(wd / "misc/broken-symlink") ==> false
+        os.exists(wd / "misc/broken-symlink", followLinks = false) ==> true
       }
     }
     test("move") {
       test - prep { wd =>
-        os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
-        os.move(wd / "folder1" / "one.txt", wd / "folder1" / "first.txt")
-        os.list(wd / "folder1") ==> Seq(wd / "folder1" / "first.txt")
+        os.list(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
+        os.move(wd / "folder1/one.txt", wd / "folder1/first.txt")
+        os.list(wd / "folder1") ==> Seq(wd / "folder1/first.txt")
 
-        os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedA", wd / "folder2" / "nestedB")
-        os.move(wd / "folder2" / "nestedA", wd / "folder2" / "nestedC")
-        os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedB", wd / "folder2" / "nestedC")
+        os.list(wd / "folder2") ==> Seq(wd / "folder2/nestedA", wd / "folder2/nestedB")
+        os.move(wd / "folder2/nestedA", wd / "folder2/nestedC")
+        os.list(wd / "folder2") ==> Seq(wd / "folder2/nestedB", wd / "folder2/nestedC")
 
         os.read(wd / "File.txt") ==> "I am cow"
         os.move(wd / "Multi Line.txt", wd / "File.txt", replaceExisting = true)
@@ -39,49 +39,49 @@ object ManipulatingFilesFoldersTests extends TestSuite {
         test - prep { wd =>
           import os.{GlobSyntax, /}
           os.walk(wd / "folder2").toSet ==> Set(
-            wd / "folder2" / "nestedA",
-            wd / "folder2" / "nestedA" / "a.txt",
-            wd / "folder2" / "nestedB",
-            wd / "folder2" / "nestedB" / "b.txt"
+            wd / "folder2/nestedA",
+            wd / "folder2/nestedA/a.txt",
+            wd / "folder2/nestedB",
+            wd / "folder2/nestedB/b.txt"
           )
 
           os.walk(wd / "folder2").collect(os.move.matching { case p / g"$x.txt" => p / g"$x.data" })
 
           os.walk(wd / "folder2").toSet ==> Set(
-            wd / "folder2" / "nestedA",
-            wd / "folder2" / "nestedA" / "a.data",
-            wd / "folder2" / "nestedB",
-            wd / "folder2" / "nestedB" / "b.data"
+            wd / "folder2/nestedA",
+            wd / "folder2/nestedA/a.data",
+            wd / "folder2/nestedB",
+            wd / "folder2/nestedB/b.data"
           )
         }
       }
       test("into") {
         test - prep { wd =>
-          os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
+          os.list(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
           os.move.into(wd / "File.txt", wd / "folder1")
-          os.list(wd / "folder1") ==> Seq(wd / "folder1" / "File.txt", wd / "folder1" / "one.txt")
+          os.list(wd / "folder1") ==> Seq(wd / "folder1/File.txt", wd / "folder1/one.txt")
         }
       }
       test("over") {
         test - prep { wd =>
-          os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedA", wd / "folder2" / "nestedB")
+          os.list(wd / "folder2") ==> Seq(wd / "folder2/nestedA", wd / "folder2/nestedB")
           os.move.over(wd / "folder1", wd / "folder2")
-          os.list(wd / "folder2") ==> Seq(wd / "folder2" / "one.txt")
+          os.list(wd / "folder2") ==> Seq(wd / "folder2/one.txt")
         }
       }
     }
     test("copy") {
       test - prep { wd =>
-        os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
-        os.copy(wd / "folder1" / "one.txt", wd / "folder1" / "first.txt")
-        os.list(wd / "folder1") ==> Seq(wd / "folder1" / "first.txt", wd / "folder1" / "one.txt")
+        os.list(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
+        os.copy(wd / "folder1/one.txt", wd / "folder1/first.txt")
+        os.list(wd / "folder1") ==> Seq(wd / "folder1/first.txt", wd / "folder1/one.txt")
 
-        os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedA", wd / "folder2" / "nestedB")
-        os.copy(wd / "folder2" / "nestedA", wd / "folder2" / "nestedC")
+        os.list(wd / "folder2") ==> Seq(wd / "folder2/nestedA", wd / "folder2/nestedB")
+        os.copy(wd / "folder2/nestedA", wd / "folder2/nestedC")
         os.list(wd / "folder2") ==> Seq(
-          wd / "folder2" / "nestedA",
-          wd / "folder2" / "nestedB",
-          wd / "folder2" / "nestedC"
+          wd / "folder2/nestedA",
+          wd / "folder2/nestedB",
+          wd / "folder2/nestedC"
         )
 
         os.read(wd / "File.txt") ==> "I am cow"
@@ -94,23 +94,23 @@ object ManipulatingFilesFoldersTests extends TestSuite {
       }
       test("into") {
         test - prep { wd =>
-          os.list(wd / "folder1") ==> Seq(wd / "folder1" / "one.txt")
+          os.list(wd / "folder1") ==> Seq(wd / "folder1/one.txt")
           os.copy.into(wd / "File.txt", wd / "folder1")
-          os.list(wd / "folder1") ==> Seq(wd / "folder1" / "File.txt", wd / "folder1" / "one.txt")
+          os.list(wd / "folder1") ==> Seq(wd / "folder1/File.txt", wd / "folder1/one.txt")
         }
       }
       test("over") {
         test - prep { wd =>
-          os.list(wd / "folder2") ==> Seq(wd / "folder2" / "nestedA", wd / "folder2" / "nestedB")
+          os.list(wd / "folder2") ==> Seq(wd / "folder2/nestedA", wd / "folder2/nestedB")
           os.copy.over(wd / "folder1", wd / "folder2")
-          os.list(wd / "folder2") ==> Seq(wd / "folder2" / "one.txt")
+          os.list(wd / "folder2") ==> Seq(wd / "folder2/one.txt")
         }
       }
       test("symlinks") {
         val src = os.temp.dir(deleteOnExit = true)
 
         os.makeDir(src / "t0")
-        os.write(src / "t0" / "file", "hello")
+        os.write(src / "t0/file", "hello")
         os.symlink(src / "t1", os.rel / "t0")
 
         val dest = os.temp.dir(deleteOnExit = true)
@@ -158,8 +158,8 @@ object ManipulatingFilesFoldersTests extends TestSuite {
       test("all") {
         test - prep { wd =>
           os.exists(wd / "new_folder") ==> false
-          os.makeDir.all(wd / "new_folder" / "inner" / "deep")
-          os.exists(wd / "new_folder" / "inner" / "deep") ==> true
+          os.makeDir.all(wd / "new_folder/inner/deep")
+          os.exists(wd / "new_folder/inner/deep") ==> true
         }
       }
     }
@@ -169,47 +169,47 @@ object ManipulatingFilesFoldersTests extends TestSuite {
         os.remove(wd / "File.txt")
         os.exists(wd / "File.txt") ==> false
 
-        os.exists(wd / "folder1" / "one.txt") ==> true
-        os.remove(wd / "folder1" / "one.txt")
+        os.exists(wd / "folder1/one.txt") ==> true
+        os.remove(wd / "folder1/one.txt")
         os.remove(wd / "folder1")
-        os.exists(wd / "folder1" / "one.txt") ==> false
+        os.exists(wd / "folder1/one.txt") ==> false
         os.exists(wd / "folder1") ==> false
       }
       test("link") {
         test - prep { wd =>
-          os.remove(wd / "misc" / "file-symlink")
-          os.exists(wd / "misc" / "file-symlink", followLinks = false) ==> false
+          os.remove(wd / "misc/file-symlink")
+          os.exists(wd / "misc/file-symlink", followLinks = false) ==> false
           os.exists(wd / "File.txt", followLinks = false) ==> true
 
-          os.remove(wd / "misc" / "folder-symlink")
-          os.exists(wd / "misc" / "folder-symlink", followLinks = false) ==> false
+          os.remove(wd / "misc/folder-symlink")
+          os.exists(wd / "misc/folder-symlink", followLinks = false) ==> false
           os.exists(wd / "folder1", followLinks = false) ==> true
-          os.exists(wd / "folder1" / "one.txt", followLinks = false) ==> true
+          os.exists(wd / "folder1/one.txt", followLinks = false) ==> true
 
-          os.remove(wd / "misc" / "broken-symlink")
-          os.exists(wd / "misc" / "broken-symlink", followLinks = false) ==> false
+          os.remove(wd / "misc/broken-symlink")
+          os.exists(wd / "misc/broken-symlink", followLinks = false) ==> false
         }
       }
       test("all") {
         test - prep { wd =>
-          os.exists(wd / "folder1" / "one.txt") ==> true
+          os.exists(wd / "folder1/one.txt") ==> true
           os.remove.all(wd / "folder1")
-          os.exists(wd / "folder1" / "one.txt") ==> false
+          os.exists(wd / "folder1/one.txt") ==> false
           os.exists(wd / "folder1") ==> false
         }
         test("link") {
           test - prep { wd =>
-            os.remove.all(wd / "misc" / "file-symlink")
-            os.exists(wd / "misc" / "file-symlink", followLinks = false) ==> false
+            os.remove.all(wd / "misc/file-symlink")
+            os.exists(wd / "misc/file-symlink", followLinks = false) ==> false
             os.exists(wd / "File.txt", followLinks = false) ==> true
 
-            os.remove.all(wd / "misc" / "folder-symlink")
-            os.exists(wd / "misc" / "folder-symlink", followLinks = false) ==> false
+            os.remove.all(wd / "misc/folder-symlink")
+            os.exists(wd / "misc/folder-symlink", followLinks = false) ==> false
             os.exists(wd / "folder1", followLinks = false) ==> true
-            os.exists(wd / "folder1" / "one.txt", followLinks = false) ==> true
+            os.exists(wd / "folder1/one.txt", followLinks = false) ==> true
 
-            os.remove.all(wd / "misc" / "broken-symlink")
-            os.exists(wd / "misc" / "broken-symlink", followLinks = false) ==> false
+            os.remove.all(wd / "misc/broken-symlink")
+            os.exists(wd / "misc/broken-symlink", followLinks = false) ==> false
           }
         }
       }
@@ -237,23 +237,23 @@ object ManipulatingFilesFoldersTests extends TestSuite {
     }
     test("followLink") {
       test - prep { wd =>
-        os.followLink(wd / "misc" / "file-symlink") ==> Some(wd / "File.txt")
-        os.followLink(wd / "misc" / "folder-symlink") ==> Some(wd / "folder1")
-        os.followLink(wd / "misc" / "broken-symlink") ==> None
+        os.followLink(wd / "misc/file-symlink") ==> Some(wd / "File.txt")
+        os.followLink(wd / "misc/folder-symlink") ==> Some(wd / "folder1")
+        os.followLink(wd / "misc/broken-symlink") ==> None
       }
     }
     test("readLink") {
       test - prep { wd =>
         if (Unix()) {
-          os.readLink(wd / "misc" / "file-symlink") ==> os.up / "File.txt"
-          os.readLink(wd / "misc" / "folder-symlink") ==> os.up / "folder1"
-          os.readLink(wd / "misc" / "broken-symlink") ==> os.rel / "broken"
-          os.readLink(wd / "misc" / "broken-abs-symlink") ==> os.root / "doesnt" / "exist"
+          os.readLink(wd / "misc/file-symlink") ==> os.up / "File.txt"
+          os.readLink(wd / "misc/folder-symlink") ==> os.up / "folder1"
+          os.readLink(wd / "misc/broken-symlink") ==> os.rel / "broken"
+          os.readLink(wd / "misc/broken-abs-symlink") ==> os.root / "doesnt/exist"
 
-          os.readLink.absolute(wd / "misc" / "file-symlink") ==> wd / "File.txt"
-          os.readLink.absolute(wd / "misc" / "folder-symlink") ==> wd / "folder1"
-          os.readLink.absolute(wd / "misc" / "broken-symlink") ==> wd / "misc" / "broken"
-          os.readLink.absolute(wd / "misc" / "broken-abs-symlink") ==> os.root / "doesnt" / "exist"
+          os.readLink.absolute(wd / "misc/file-symlink") ==> wd / "File.txt"
+          os.readLink.absolute(wd / "misc/folder-symlink") ==> wd / "folder1"
+          os.readLink.absolute(wd / "misc/broken-symlink") ==> wd / "misc/broken"
+          os.readLink.absolute(wd / "misc/broken-abs-symlink") ==> os.root / "doesnt/exist"
         }
       }
     }

--- a/os/test/src/OpTests.scala
+++ b/os/test/src/OpTests.scala
@@ -10,7 +10,7 @@ import java.nio.charset.Charset
 object OpTests extends TestSuite {
 
   val tests = Tests {
-    val res = os.pwd / "os" / "test" / "resources" / "test"
+    val res = os.pwd / "os/test/resources/test"
     test("ls") - assert(
       os.list(res).toSet == Set(
         res / "folder1",
@@ -21,38 +21,38 @@ object OpTests extends TestSuite {
         res / "Multi Line.txt"
       ),
       os.list(res / "folder2").toSet == Set(
-        res / "folder2" / "nestedA",
-        res / "folder2" / "nestedB"
+        res / "folder2/nestedA",
+        res / "folder2/nestedB"
       )
     )
     test("rm") {
       // shouldn't crash
-      os.remove.all(os.pwd / "out" / "scratch" / "nonexistent")
+      os.remove.all(os.pwd / "out/scratch/nonexistent")
       // shouldn't crash
-      os.remove(os.pwd / "out" / "scratch" / "nonexistent") ==> false
+      os.remove(os.pwd / "out/scratch/nonexistent") ==> false
 
       // should crash
       intercept[NoSuchFileException] {
-        os.remove(os.pwd / "out" / "scratch" / "nonexistent", checkExists = true)
+        os.remove(os.pwd / "out/scratch/nonexistent", checkExists = true)
       }
     }
     test("lsR") {
       os.walk(res).foreach(println)
       intercept[java.nio.file.NoSuchFileException](
-        os.walk(os.pwd / "out" / "scratch" / "nonexistent")
+        os.walk(os.pwd / "out/scratch/nonexistent")
       )
       assert(
-        os.walk(res / "folder2" / "nestedB") == Seq(res / "folder2" / "nestedB" / "b.txt"),
+        os.walk(res / "folder2/nestedB") == Seq(res / "folder2/nestedB/b.txt"),
         os.walk(res / "folder2").toSet == Set(
-          res / "folder2" / "nestedA",
-          res / "folder2" / "nestedA" / "a.txt",
-          res / "folder2" / "nestedB",
-          res / "folder2" / "nestedB" / "b.txt"
+          res / "folder2/nestedA",
+          res / "folder2/nestedA/a.txt",
+          res / "folder2/nestedB",
+          res / "folder2/nestedB/b.txt"
         )
       )
     }
     test("Mutating") {
-      val testFolder = os.pwd / "out" / "scratch" / "test"
+      val testFolder = os.pwd / "out/scratch/test"
       os.remove.all(testFolder)
       os.makeDir.all(testFolder)
       test("cp") {
@@ -82,17 +82,17 @@ object OpTests extends TestSuite {
           )
         }
         test("deep") {
-          os.write(d / "folderA" / "folderB" / "file", "Cow", createFolders = true)
+          os.write(d / "folderA/folderB/file", "Cow", createFolders = true)
           os.copy(d / "folderA", d / "folderC")
-          assert(os.read(d / "folderC" / "folderB" / "file") == "Cow")
+          assert(os.read(d / "folderC/folderB/file") == "Cow")
         }
         test("merging") {
           val mergeDir = d / "merge"
-          os.write(mergeDir / "folderA" / "folderB" / "file", "Cow", createFolders = true)
-          os.write(mergeDir / "folderC" / "file", "moo", createFolders = true)
+          os.write(mergeDir / "folderA/folderB/file", "Cow", createFolders = true)
+          os.write(mergeDir / "folderC/file", "moo", createFolders = true)
           os.copy(mergeDir / "folderA", mergeDir / "folderC", mergeFolders = true)
-          assert(os.read(mergeDir / "folderC" / "folderB" / "file") == "Cow")
-          assert(os.read(mergeDir / "folderC" / "file") == "moo")
+          assert(os.read(mergeDir / "folderC/folderB/file") == "Cow")
+          assert(os.read(mergeDir / "folderC/file") == "moo")
         }
       }
       test("mv") {
@@ -130,19 +130,19 @@ object OpTests extends TestSuite {
           val d = testFolder / "moving2"
           os.makeDir(d)
           os.makeDir(d / "scala")
-          os.write(d / "scala" / "A", "AScala")
-          os.write(d / "scala" / "B", "BScala")
+          os.write(d / "scala/A", "AScala")
+          os.write(d / "scala/B", "BScala")
           os.makeDir(d / "py")
-          os.write(d / "py" / "A", "APy")
-          os.write(d / "py" / "B", "BPy")
+          os.write(d / "py/A", "APy")
+          os.write(d / "py/B", "BPy")
           test("partialMoves") {
             os.walk(d).collect(os.move.matching { case d / "py" / x => d / x })
             assert(
               os.walk(d).toSet == Set(
                 d / "py",
                 d / "scala",
-                d / "scala" / "A",
-                d / "scala" / "B",
+                d / "scala/A",
+                d / "scala/B",
                 d / "A",
                 d / "B"
               )
@@ -153,8 +153,8 @@ object OpTests extends TestSuite {
             intercept[MatchError] { die }
 
             os.walk(d).filter(os.isFile).map(os.move.matching {
-              case d / "py" / x => d / "scala" / "py" / x
-              case d / "scala" / x => d / "py" / "scala" / x
+              case d / "py" / x => d / "scala/py" / x
+              case d / "scala" / x => d / "py/scala" / x
               case d => println("NOT FOUND " + d); d
             })
 
@@ -162,12 +162,12 @@ object OpTests extends TestSuite {
               os.walk(d).toSet == Set(
                 d / "py",
                 d / "scala",
-                d / "py" / "scala",
-                d / "scala" / "py",
-                d / "scala" / "py" / "A",
-                d / "scala" / "py" / "B",
-                d / "py" / "scala" / "A",
-                d / "py" / "scala" / "B"
+                d / "py/scala",
+                d / "scala/py",
+                d / "scala/py/A",
+                d / "scala/py/B",
+                d / "py/scala/A",
+                d / "py/scala/B"
               )
             )
           }
@@ -185,11 +185,11 @@ object OpTests extends TestSuite {
         }
         test("nestedFolders") {
           val nested = testFolder / "nested"
-          os.makeDir.all(nested / "inner" / "innerer" / "innerest")
+          os.makeDir.all(nested / "inner/innerer/innerest")
           assert(
             os.list(nested) == Seq(nested / "inner"),
-            os.list(nested / "inner") == Seq(nested / "inner" / "innerer"),
-            os.list(nested / "inner" / "innerer") == Seq(nested / "inner" / "innerer" / "innerest")
+            os.list(nested / "inner") == Seq(nested / "inner/innerer"),
+            os.list(nested / "inner/innerer") == Seq(nested / "inner/innerer/innerest")
           )
           os.remove.all(nested / "inner")
           assert(os.list(nested) == Seq())
@@ -204,8 +204,8 @@ object OpTests extends TestSuite {
           assert(os.read(d / "file") == "i am a cow")
         }
         test("autoMkdir") {
-          os.write(d / "folder" / "folder" / "file", "i am a cow", createFolders = true)
-          assert(os.read(d / "folder" / "folder" / "file") == "i am a cow")
+          os.write(d / "folder/folder/file", "i am a cow", createFolders = true)
+          assert(os.read(d / "folder/folder/file") == "i am a cow")
         }
         test("binary") {
           os.write(d / "file", Array[Byte](1, 2, 3, 4))

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -16,16 +16,16 @@ object PathTests extends TestSuite {
   val tests = Tests {
     test("Literals") {
       test("Basic") {
-        assert(rel / "src/Main/.scala" == rel / "src/Main/.scala")
-        assert(root / "core/src/test" == root / "core/src/test")
-        assert(root / "core/src/test" == root / "core/src/test")
+        assert(rel / "src" / "Main/.scala" == rel / "src" / "Main" / ".scala")
+        assert(root / "core/src/test" == root / "core" / "src" / "test")
+        assert(root / "core/src/test" == root / "core" / "src/test")
       }
       test("literals with [..]") {
-        assert(rel / "src/.." == rel / "src" / os.up)
+        assert(rel / "src" / ".." == rel / "src" / os.up)
         assert(root / "src/.." == root / "src" / os.up)
-        assert(root / "src/.." == root / "src" / os.up)
-        assert(root / "hello/../world" == root / "hello" / os.up / "world")
-        assert(root / "hello/../world" == root / "hello" / os.up / "world")
+        assert(root / "src" / ".." == root / "src" / os.up)
+        assert(root / "hello" / ".." / "world" == root / "hello" / os.up / "world")
+        assert(root / "hello" / "../world" == root / "hello" / os.up / "world")
         assert(root / "hello/../world" == root / "hello" / os.up / "world")
       }
 
@@ -49,8 +49,8 @@ object PathTests extends TestSuite {
 
         compileError("""root / "//foo/" """).check("", nonCanonicalLiteral("//foo/", "foo"))
 
-        compileError(""" rel / "src/" """).check("", removeLiteralErr(""))
-        compileError(""" rel / "src/." """).check("", removeLiteralErr("."))
+        compileError(""" rel / "src" / "" """).check("", removeLiteralErr(""))
+        compileError(""" rel / "src" / "." """).check("", removeLiteralErr("."))
 
         compileError(""" root / "src/"  """).check("", nonCanonicalLiteral("src/", "src"))
         compileError(""" root / "src/." """).check("", nonCanonicalLiteral("src/.", "src"))
@@ -61,8 +61,8 @@ object PathTests extends TestSuite {
       }
     }
     test("Basic") {
-      val base = rel / "src/main/scala"
-      val subBase = sub / "src/main/scala"
+      val base = rel / "src" / "main" / "scala"
+      val subBase = sub / "src" / "main" / "scala"
 
       test("Transform posix paths") {
         // verify posix string format of driveRelative path
@@ -194,13 +194,13 @@ object PathTests extends TestSuite {
         }
         test("Relativize") {
           def eq[T](p: T, q: T) = assert(p == q)
-          test - eq(rel / "omg/bbq/wtf" relativeTo rel / "omg/bbq/wtf", rel)
-          test - eq(rel / "omg/bbq" relativeTo rel / "omg/bbq/wtf", up)
-          test - eq(rel / "omg/bbq/wtf" relativeTo rel / "omg/bbq", rel / "wtf")
-          test - eq(rel / "omg/bbq" relativeTo rel / "omg/bbq/wtf", up)
-          test - eq(up / "omg/bbq" relativeTo rel / "omg/bbq", up / up / up / "omg/bbq")
+          test - eq(rel / "omg" / "bbq" / "wtf" relativeTo rel / "omg" / "bbq" / "wtf", rel)
+          test - eq(rel / "omg" / "bbq" relativeTo rel / "omg" / "bbq" / "wtf", up)
+          test - eq(rel / "omg" / "bbq" / "wtf" relativeTo rel / "omg" / "bbq", rel / "wtf")
+          test - eq(rel / "omg" / "bbq" relativeTo rel / "omg" / "bbq" / "wtf", up)
+          test - eq(up / "omg" / "bbq" relativeTo rel / "omg" / "bbq", up / up / up / "omg" / "bbq")
           test - intercept[PathError.NoRelativePath](
-            rel / "omg/bbq" relativeTo up / "omg/bbq"
+            rel / "omg" / "bbq" relativeTo up / "omg" / "bbq"
           )
         }
       }
@@ -248,10 +248,10 @@ object PathTests extends TestSuite {
         }
         test("Relativize") {
           def eq[T](p: T, q: T) = assert(p == q)
-          test - eq(sub / "omg/bbq/wtf" relativeTo sub / "omg/bbq/wtf", rel)
-          test - eq(sub / "omg/bbq" relativeTo sub / "omg/bbq/wtf", up)
-          test - eq(sub / "omg/bbq/wtf" relativeTo sub / "omg/bbq", rel / "wtf")
-          test - eq(sub / "omg/bbq" relativeTo sub / "omg/bbq/wtf", up)
+          test - eq(sub / "omg" / "bbq" / "wtf" relativeTo sub / "omg" / "bbq" / "wtf", rel)
+          test - eq(sub / "omg" / "bbq" relativeTo sub / "omg" / "bbq" / "wtf", up)
+          test - eq(sub / "omg" / "bbq" / "wtf" relativeTo sub / "omg" / "bbq", rel / "wtf")
+          test - eq(sub / "omg" / "bbq" relativeTo sub / "omg" / "bbq" / "wtf", up)
         }
       }
 
@@ -266,24 +266,24 @@ object PathTests extends TestSuite {
         }
         test("Relativize") {
           def eq[T](p: T, q: T) = assert(p == q)
-          test - eq(root / "omg/bbq/wtf" relativeTo root / "omg/bbq/wtf", rel)
-          test - eq(root / "omg/bbq" relativeTo root / "omg/bbq/wtf", up)
-          test - eq(root / "omg/bbq/wtf" relativeTo root / "omg/bbq", rel / "wtf")
-          test - eq(root / "omg/bbq" relativeTo root / "omg/bbq/wtf", up)
+          test - eq(root / "omg" / "bbq" / "wtf" relativeTo root / "omg" / "bbq" / "wtf", rel)
+          test - eq(root / "omg" / "bbq" relativeTo root / "omg" / "bbq" / "wtf", up)
+          test - eq(root / "omg" / "bbq" / "wtf" relativeTo root / "omg" / "bbq", rel / "wtf")
+          test - eq(root / "omg" / "bbq" relativeTo root / "omg" / "bbq" / "wtf", up)
           test - intercept[PathError.NoRelativePath](
-            rel / "omg/bbq" relativeTo up / "omg/bbq"
+            rel / "omg" / "bbq" relativeTo up / "omg" / "bbq"
           )
         }
       }
       test("Ups") {
         test("RelativeUps") {
           val rel2 = base / up
-          assert(rel2 == rel / "src/main")
+          assert(rel2 == rel / "src" / "main")
           assert(base / up / up == rel / "src")
           assert(base / up / up / up == rel)
           assert(base / up / up / up / up == up)
           assert(base / up / up / up / up / up == up / up)
-          assert(up / base == up / "src/main/scala")
+          assert(up / base == up / "src" / "main" / "scala")
         }
         test("AbsoluteUps") {
           // Keep applying `up` and verify that the path gets
@@ -306,21 +306,21 @@ object PathTests extends TestSuite {
       }
       test("Comparison") {
         test("Relative") - {
-          assert(rel / "omg/wtf" == rel / "omg/wtf")
-          assert(rel / "omg/wtf" != rel / "omg/wtf/bbq")
-          assert(rel / "omg/wtf/bbq" startsWith rel / "omg/wtf")
-          assert(rel / "omg/wtf" startsWith rel / "omg/wtf")
-          assert(up / "omg/wtf" startsWith up / "omg/wtf")
-          assert(!(rel / "omg/wtf" startsWith rel / "omg/wtf/bbq"))
-          assert(!(up / "omg/wtf" startsWith rel / "omg/wtf"))
-          assert(!(rel / "omg/wtf" startsWith up / "omg/wtf"))
+          assert(rel / "omg" / "wtf" == rel / "omg" / "wtf")
+          assert(rel / "omg" / "wtf" != rel / "omg" / "wtf" / "bbq")
+          assert(rel / "omg" / "wtf" / "bbq" startsWith rel / "omg" / "wtf")
+          assert(rel / "omg" / "wtf" startsWith rel / "omg" / "wtf")
+          assert(up / "omg" / "wtf" startsWith up / "omg" / "wtf")
+          assert(!(rel / "omg" / "wtf" startsWith rel / "omg" / "wtf" / "bbq"))
+          assert(!(up / "omg" / "wtf" startsWith rel / "omg" / "wtf"))
+          assert(!(rel / "omg" / "wtf" startsWith up / "omg" / "wtf"))
         }
         test("Absolute") - {
-          assert(root / "omg/wtf" == root / "omg/wtf")
-          assert(root / "omg/wtf" != root / "omg/wtf/bbq")
-          assert(root / "omg/wtf/bbq" startsWith root / "omg/wtf")
-          assert(root / "omg/wtf" startsWith root / "omg/wtf")
-          assert(!(root / "omg/wtf" startsWith root / "omg/wtf/bbq"))
+          assert(root / "omg" / "wtf" == root / "omg" / "wtf")
+          assert(root / "omg" / "wtf" != root / "omg" / "wtf" / "bbq")
+          assert(root / "omg" / "wtf" / "bbq" startsWith root / "omg" / "wtf")
+          assert(root / "omg" / "wtf" startsWith root / "omg" / "wtf")
+          assert(!(root / "omg" / "wtf" startsWith root / "omg" / "wtf" / "bbq"))
         }
         test("Invalid") {
           compileError("""root/"omg"/"wtf" < "omg"/"wtf"""")
@@ -365,7 +365,7 @@ object PathTests extends TestSuite {
       }
       test("CannotRelativizeAbsAndRel") {
         val abs = pwd
-        val rel = os.rel / "omg/wtf"
+        val rel = os.rel / "omg" / "wtf"
         compileError("""
         abs.relativeTo(rel)
       """).msg.toLowerCase.contains("required: os.path") ==> true
@@ -385,7 +385,7 @@ object PathTests extends TestSuite {
     }
     test("Extractors") {
       test("paths") {
-        val a / b / c / d / "omg" = pwd / "A/B/C/D/omg"
+        val a / b / c / d / "omg" = pwd / "A" / "B" / "C" / "D" / "omg"
         assert(a == pwd / "A")
         assert(b == "B")
         assert(c == "C")
@@ -408,8 +408,8 @@ object PathTests extends TestSuite {
       }
 
       test - assert(
-        Seq(up / "c", up / up / "c", rel / "b/c", rel / "a/c", rel / "a/d").sorted ==
-          Seq(rel / "a/c", rel / "a/d", rel / "b/c", up / "c", up / up / "c")
+        Seq(up / "c", up / up / "c", rel / "b" / "c", rel / "a" / "c", rel / "a" / "d").sorted ==
+          Seq(rel / "a" / "c", rel / "a" / "d", rel / "b" / "c", up / "c", up / up / "c")
       )
 
       test - assert(
@@ -423,9 +423,9 @@ object PathTests extends TestSuite {
         val absStr = "/hello/world"
 
         val lhs = Path(absStr)
-        val rhs = root / "hello/world"
+        val rhs = root / "hello" / "world"
         assert(
-          RelPath(relStr) == rel / "hello/cow",
+          RelPath(relStr) == rel / "hello" / "cow",
           // Path(...) also allows paths starting with ~,
           // which is expanded to become your home directory
           lhs == rhs
@@ -436,25 +436,25 @@ object PathTests extends TestSuite {
         val relIoFile = new java.io.File(relStr)
         val absNioFile = java.nio.file.Paths.get(absStr)
 
-        assert(RelPath(relIoFile) == rel / "hello/cow")
-        assert(Path(absNioFile) == root / "hello/world")
-        assert(Path(relIoFile, root / "base") == root / "base/hello/cow")
+        assert(RelPath(relIoFile) == rel / "hello" / "cow")
+        assert(Path(absNioFile) == root / "hello" / "world")
+        assert(Path(relIoFile, root / "base") == root / "base" / "hello" / "cow")
       }
       test("basepath") {
         val relStr = "hello/cow/world/.."
         val absStr = "/hello/world"
         assert(
-          FilePath(relStr) == rel / "hello/cow",
-          FilePath(absStr) == root / "hello/world"
+          FilePath(relStr) == rel / "hello" / "cow",
+          FilePath(absStr) == root / "hello" / "world"
         )
       }
       test("based") {
         val relStr = "hello/cow/world/.."
         val absStr = "/hello/world"
         val basePath: FilePath = FilePath(relStr)
-        assert(Path(relStr, root / "base") == root / "base/hello/cow")
-        assert(Path(absStr, root / "base") == root / "hello/world")
-        assert(Path(basePath, root / "base") == root / "base/hello/cow")
+        assert(Path(relStr, root / "base") == root / "base" / "hello" / "cow")
+        assert(Path(absStr, root / "base") == root / "hello" / "world")
+        assert(Path(basePath, root / "base") == root / "base" / "hello" / "cow")
         assert(Path(".", pwd).last != "")
       }
       test("failure") {
@@ -477,16 +477,16 @@ object PathTests extends TestSuite {
     test("issue159") {
       val result1 = os.rel / Seq(os.up, os.rel / "hello", os.rel / "world")
       val result2 = os.rel / Array(os.up, os.rel / "hello", os.rel / "world")
-      val expected = os.up / "hello/world"
+      val expected = os.up / "hello" / "world"
       assert(result1 == expected)
       assert(result2 == expected)
     }
     test("custom root") {
       assert(os.root == os.root(os.root.root))
       File.listRoots().foreach { root =>
-        val path = os.root(root.toPath().toString) / "test/dir"
+        val path = os.root(root.toPath().toString) / "test" / "dir"
         assert(path.root == root.toString)
-        assert(path.relativeTo(os.root(root.toPath().toString)) == rel / "test/dir")
+        assert(path.relativeTo(os.root(root.toPath().toString)) == rel / "test" / "dir")
       }
     }
     test("issue201") {

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -16,16 +16,16 @@ object PathTests extends TestSuite {
   val tests = Tests {
     test("Literals") {
       test("Basic") {
-        assert(rel / "src" / "Main/.scala" == rel / "src" / "Main" / ".scala")
-        assert(root / "core/src/test" == root / "core" / "src" / "test")
-        assert(root / "core/src/test" == root / "core" / "src/test")
+        assert(rel / "src/Main/.scala" == rel / "src/Main/.scala")
+        assert(root / "core/src/test" == root / "core/src/test")
+        assert(root / "core/src/test" == root / "core/src/test")
       }
       test("literals with [..]") {
-        assert(rel / "src" / ".." == rel / "src" / os.up)
+        assert(rel / "src/.." == rel / "src" / os.up)
         assert(root / "src/.." == root / "src" / os.up)
-        assert(root / "src" / ".." == root / "src" / os.up)
-        assert(root / "hello" / ".." / "world" == root / "hello" / os.up / "world")
-        assert(root / "hello" / "../world" == root / "hello" / os.up / "world")
+        assert(root / "src/.." == root / "src" / os.up)
+        assert(root / "hello/../world" == root / "hello" / os.up / "world")
+        assert(root / "hello/../world" == root / "hello" / os.up / "world")
         assert(root / "hello/../world" == root / "hello" / os.up / "world")
       }
 
@@ -49,8 +49,8 @@ object PathTests extends TestSuite {
 
         compileError("""root / "//foo/" """).check("", nonCanonicalLiteral("//foo/", "foo"))
 
-        compileError(""" rel / "src" / "" """).check("", removeLiteralErr(""))
-        compileError(""" rel / "src" / "." """).check("", removeLiteralErr("."))
+        compileError(""" rel / "src/" """).check("", removeLiteralErr(""))
+        compileError(""" rel / "src/." """).check("", removeLiteralErr("."))
 
         compileError(""" root / "src/"  """).check("", nonCanonicalLiteral("src/", "src"))
         compileError(""" root / "src/." """).check("", nonCanonicalLiteral("src/.", "src"))
@@ -61,8 +61,8 @@ object PathTests extends TestSuite {
       }
     }
     test("Basic") {
-      val base = rel / "src" / "main" / "scala"
-      val subBase = sub / "src" / "main" / "scala"
+      val base = rel / "src/main/scala"
+      val subBase = sub / "src/main/scala"
 
       test("Transform posix paths") {
         // verify posix string format of driveRelative path
@@ -194,13 +194,13 @@ object PathTests extends TestSuite {
         }
         test("Relativize") {
           def eq[T](p: T, q: T) = assert(p == q)
-          test - eq(rel / "omg" / "bbq" / "wtf" relativeTo rel / "omg" / "bbq" / "wtf", rel)
-          test - eq(rel / "omg" / "bbq" relativeTo rel / "omg" / "bbq" / "wtf", up)
-          test - eq(rel / "omg" / "bbq" / "wtf" relativeTo rel / "omg" / "bbq", rel / "wtf")
-          test - eq(rel / "omg" / "bbq" relativeTo rel / "omg" / "bbq" / "wtf", up)
-          test - eq(up / "omg" / "bbq" relativeTo rel / "omg" / "bbq", up / up / up / "omg" / "bbq")
+          test - eq(rel / "omg/bbq/wtf" relativeTo rel / "omg/bbq/wtf", rel)
+          test - eq(rel / "omg/bbq" relativeTo rel / "omg/bbq/wtf", up)
+          test - eq(rel / "omg/bbq/wtf" relativeTo rel / "omg/bbq", rel / "wtf")
+          test - eq(rel / "omg/bbq" relativeTo rel / "omg/bbq/wtf", up)
+          test - eq(up / "omg/bbq" relativeTo rel / "omg/bbq", up / up / up / "omg/bbq")
           test - intercept[PathError.NoRelativePath](
-            rel / "omg" / "bbq" relativeTo up / "omg" / "bbq"
+            rel / "omg/bbq" relativeTo up / "omg/bbq"
           )
         }
       }
@@ -248,10 +248,10 @@ object PathTests extends TestSuite {
         }
         test("Relativize") {
           def eq[T](p: T, q: T) = assert(p == q)
-          test - eq(sub / "omg" / "bbq" / "wtf" relativeTo sub / "omg" / "bbq" / "wtf", rel)
-          test - eq(sub / "omg" / "bbq" relativeTo sub / "omg" / "bbq" / "wtf", up)
-          test - eq(sub / "omg" / "bbq" / "wtf" relativeTo sub / "omg" / "bbq", rel / "wtf")
-          test - eq(sub / "omg" / "bbq" relativeTo sub / "omg" / "bbq" / "wtf", up)
+          test - eq(sub / "omg/bbq/wtf" relativeTo sub / "omg/bbq/wtf", rel)
+          test - eq(sub / "omg/bbq" relativeTo sub / "omg/bbq/wtf", up)
+          test - eq(sub / "omg/bbq/wtf" relativeTo sub / "omg/bbq", rel / "wtf")
+          test - eq(sub / "omg/bbq" relativeTo sub / "omg/bbq/wtf", up)
         }
       }
 
@@ -266,24 +266,24 @@ object PathTests extends TestSuite {
         }
         test("Relativize") {
           def eq[T](p: T, q: T) = assert(p == q)
-          test - eq(root / "omg" / "bbq" / "wtf" relativeTo root / "omg" / "bbq" / "wtf", rel)
-          test - eq(root / "omg" / "bbq" relativeTo root / "omg" / "bbq" / "wtf", up)
-          test - eq(root / "omg" / "bbq" / "wtf" relativeTo root / "omg" / "bbq", rel / "wtf")
-          test - eq(root / "omg" / "bbq" relativeTo root / "omg" / "bbq" / "wtf", up)
+          test - eq(root / "omg/bbq/wtf" relativeTo root / "omg/bbq/wtf", rel)
+          test - eq(root / "omg/bbq" relativeTo root / "omg/bbq/wtf", up)
+          test - eq(root / "omg/bbq/wtf" relativeTo root / "omg/bbq", rel / "wtf")
+          test - eq(root / "omg/bbq" relativeTo root / "omg/bbq/wtf", up)
           test - intercept[PathError.NoRelativePath](
-            rel / "omg" / "bbq" relativeTo up / "omg" / "bbq"
+            rel / "omg/bbq" relativeTo up / "omg/bbq"
           )
         }
       }
       test("Ups") {
         test("RelativeUps") {
           val rel2 = base / up
-          assert(rel2 == rel / "src" / "main")
+          assert(rel2 == rel / "src/main")
           assert(base / up / up == rel / "src")
           assert(base / up / up / up == rel)
           assert(base / up / up / up / up == up)
           assert(base / up / up / up / up / up == up / up)
-          assert(up / base == up / "src" / "main" / "scala")
+          assert(up / base == up / "src/main/scala")
         }
         test("AbsoluteUps") {
           // Keep applying `up` and verify that the path gets
@@ -306,21 +306,21 @@ object PathTests extends TestSuite {
       }
       test("Comparison") {
         test("Relative") - {
-          assert(rel / "omg" / "wtf" == rel / "omg" / "wtf")
-          assert(rel / "omg" / "wtf" != rel / "omg" / "wtf" / "bbq")
-          assert(rel / "omg" / "wtf" / "bbq" startsWith rel / "omg" / "wtf")
-          assert(rel / "omg" / "wtf" startsWith rel / "omg" / "wtf")
-          assert(up / "omg" / "wtf" startsWith up / "omg" / "wtf")
-          assert(!(rel / "omg" / "wtf" startsWith rel / "omg" / "wtf" / "bbq"))
-          assert(!(up / "omg" / "wtf" startsWith rel / "omg" / "wtf"))
-          assert(!(rel / "omg" / "wtf" startsWith up / "omg" / "wtf"))
+          assert(rel / "omg/wtf" == rel / "omg/wtf")
+          assert(rel / "omg/wtf" != rel / "omg/wtf/bbq")
+          assert(rel / "omg/wtf/bbq" startsWith rel / "omg/wtf")
+          assert(rel / "omg/wtf" startsWith rel / "omg/wtf")
+          assert(up / "omg/wtf" startsWith up / "omg/wtf")
+          assert(!(rel / "omg/wtf" startsWith rel / "omg/wtf/bbq"))
+          assert(!(up / "omg/wtf" startsWith rel / "omg/wtf"))
+          assert(!(rel / "omg/wtf" startsWith up / "omg/wtf"))
         }
         test("Absolute") - {
-          assert(root / "omg" / "wtf" == root / "omg" / "wtf")
-          assert(root / "omg" / "wtf" != root / "omg" / "wtf" / "bbq")
-          assert(root / "omg" / "wtf" / "bbq" startsWith root / "omg" / "wtf")
-          assert(root / "omg" / "wtf" startsWith root / "omg" / "wtf")
-          assert(!(root / "omg" / "wtf" startsWith root / "omg" / "wtf" / "bbq"))
+          assert(root / "omg/wtf" == root / "omg/wtf")
+          assert(root / "omg/wtf" != root / "omg/wtf/bbq")
+          assert(root / "omg/wtf/bbq" startsWith root / "omg/wtf")
+          assert(root / "omg/wtf" startsWith root / "omg/wtf")
+          assert(!(root / "omg/wtf" startsWith root / "omg/wtf/bbq"))
         }
         test("Invalid") {
           compileError("""root/"omg"/"wtf" < "omg"/"wtf"""")
@@ -365,7 +365,7 @@ object PathTests extends TestSuite {
       }
       test("CannotRelativizeAbsAndRel") {
         val abs = pwd
-        val rel = os.rel / "omg" / "wtf"
+        val rel = os.rel / "omg/wtf"
         compileError("""
         abs.relativeTo(rel)
       """).msg.toLowerCase.contains("required: os.path") ==> true
@@ -385,7 +385,7 @@ object PathTests extends TestSuite {
     }
     test("Extractors") {
       test("paths") {
-        val a / b / c / d / "omg" = pwd / "A" / "B" / "C" / "D" / "omg"
+        val a / b / c / d / "omg" = pwd / "A/B/C/D/omg"
         assert(a == pwd / "A")
         assert(b == "B")
         assert(c == "C")
@@ -408,8 +408,8 @@ object PathTests extends TestSuite {
       }
 
       test - assert(
-        Seq(up / "c", up / up / "c", rel / "b" / "c", rel / "a" / "c", rel / "a" / "d").sorted ==
-          Seq(rel / "a" / "c", rel / "a" / "d", rel / "b" / "c", up / "c", up / up / "c")
+        Seq(up / "c", up / up / "c", rel / "b/c", rel / "a/c", rel / "a/d").sorted ==
+          Seq(rel / "a/c", rel / "a/d", rel / "b/c", up / "c", up / up / "c")
       )
 
       test - assert(
@@ -423,9 +423,9 @@ object PathTests extends TestSuite {
         val absStr = "/hello/world"
 
         val lhs = Path(absStr)
-        val rhs = root / "hello" / "world"
+        val rhs = root / "hello/world"
         assert(
-          RelPath(relStr) == rel / "hello" / "cow",
+          RelPath(relStr) == rel / "hello/cow",
           // Path(...) also allows paths starting with ~,
           // which is expanded to become your home directory
           lhs == rhs
@@ -436,25 +436,25 @@ object PathTests extends TestSuite {
         val relIoFile = new java.io.File(relStr)
         val absNioFile = java.nio.file.Paths.get(absStr)
 
-        assert(RelPath(relIoFile) == rel / "hello" / "cow")
-        assert(Path(absNioFile) == root / "hello" / "world")
-        assert(Path(relIoFile, root / "base") == root / "base" / "hello" / "cow")
+        assert(RelPath(relIoFile) == rel / "hello/cow")
+        assert(Path(absNioFile) == root / "hello/world")
+        assert(Path(relIoFile, root / "base") == root / "base/hello/cow")
       }
       test("basepath") {
         val relStr = "hello/cow/world/.."
         val absStr = "/hello/world"
         assert(
-          FilePath(relStr) == rel / "hello" / "cow",
-          FilePath(absStr) == root / "hello" / "world"
+          FilePath(relStr) == rel / "hello/cow",
+          FilePath(absStr) == root / "hello/world"
         )
       }
       test("based") {
         val relStr = "hello/cow/world/.."
         val absStr = "/hello/world"
         val basePath: FilePath = FilePath(relStr)
-        assert(Path(relStr, root / "base") == root / "base" / "hello" / "cow")
-        assert(Path(absStr, root / "base") == root / "hello" / "world")
-        assert(Path(basePath, root / "base") == root / "base" / "hello" / "cow")
+        assert(Path(relStr, root / "base") == root / "base/hello/cow")
+        assert(Path(absStr, root / "base") == root / "hello/world")
+        assert(Path(basePath, root / "base") == root / "base/hello/cow")
         assert(Path(".", pwd).last != "")
       }
       test("failure") {
@@ -477,16 +477,16 @@ object PathTests extends TestSuite {
     test("issue159") {
       val result1 = os.rel / Seq(os.up, os.rel / "hello", os.rel / "world")
       val result2 = os.rel / Array(os.up, os.rel / "hello", os.rel / "world")
-      val expected = os.up / "hello" / "world"
+      val expected = os.up / "hello/world"
       assert(result1 == expected)
       assert(result2 == expected)
     }
     test("custom root") {
       assert(os.root == os.root(os.root.root))
       File.listRoots().foreach { root =>
-        val path = os.root(root.toPath().toString) / "test" / "dir"
+        val path = os.root(root.toPath().toString) / "test/dir"
         assert(path.root == root.toString)
-        assert(path.relativeTo(os.root(root.toPath().toString)) == rel / "test" / "dir")
+        assert(path.relativeTo(os.root(root.toPath().toString)) == rel / "test/dir")
       }
     }
     test("issue201") {

--- a/os/test/src/ReadingWritingTests.scala
+++ b/os/test/src/ReadingWritingTests.scala
@@ -6,7 +6,7 @@ object ReadingWritingTests extends TestSuite {
     test("read") {
       test - prep { wd =>
         os.read(wd / "File.txt") ==> "I am cow"
-        os.read(wd / "folder1" / "one.txt") ==> "Contents of folder one"
+        os.read(wd / "folder1/one.txt") ==> "Contents of folder one"
         os.read(wd / "Multi Line.txt") ==>
           """I am cow
             |Hear me moo
@@ -31,7 +31,7 @@ object ReadingWritingTests extends TestSuite {
       test("bytes") {
         test - prep { wd =>
           os.read.bytes(wd / "File.txt") ==> "I am cow".getBytes
-          os.read.bytes(wd / "misc" / "binary.png").length ==> 711
+          os.read.bytes(wd / "misc/binary.png").length ==> 711
         }
       }
       test("chunks") {
@@ -92,9 +92,9 @@ object ReadingWritingTests extends TestSuite {
           os.read(wd / "File.txt") ==>
             "I am cow, hear me moo,\nI weigh twice as much as you"
 
-          os.read.bytes(wd / "misc" / "binary.png").length ==> 711
-          os.write.append(wd / "misc" / "binary.png", Array[Byte](1, 2, 3))
-          os.read.bytes(wd / "misc" / "binary.png").length ==> 714
+          os.read.bytes(wd / "misc/binary.png").length ==> 711
+          os.write.append(wd / "misc/binary.png", Array[Byte](1, 2, 3))
+          os.read.bytes(wd / "misc/binary.png").length ==> 714
         }
       }
       test("over") {

--- a/os/test/src/SubprocessTests.scala
+++ b/os/test/src/SubprocessTests.scala
@@ -9,7 +9,7 @@ import utest._
 import scala.collection.mutable
 
 object SubprocessTests extends TestSuite {
-  val scriptFolder = pwd / "os" / "test" / "resources" / "test"
+  val scriptFolder = pwd / "os/test/resources/test"
 
   val lsCmd = if (scala.util.Properties.isWin) "dir" else "ls"
 
@@ -32,7 +32,7 @@ object SubprocessTests extends TestSuite {
     }
     test("bytes") {
       if (Unix()) {
-        val res = proc(scriptFolder / "misc" / "echo", "abc").call()
+        val res = proc(scriptFolder / "misc/echo", "abc").call()
         val listed = res.out.bytes
         listed ==> "abc\n".getBytes
       }
@@ -71,10 +71,10 @@ object SubprocessTests extends TestSuite {
 
     test("filebased") {
       if (Unix()) {
-        assert(proc(scriptFolder / "misc" / "echo", "HELLO").call().out.lines().mkString == "HELLO")
+        assert(proc(scriptFolder / "misc/echo", "HELLO").call().out.lines().mkString == "HELLO")
 
         val res: CommandResult =
-          proc(root / "bin" / "bash", "-c", "echo 'Hello'$ENV_ARG").call(
+          proc(root / "bin/bash", "-c", "echo 'Hello'$ENV_ARG").call(
             env = Map("ENV_ARG" -> "123")
           )
 
@@ -83,7 +83,7 @@ object SubprocessTests extends TestSuite {
     }
     test("filebased2") {
       if (Unix()) {
-        val possiblePaths = Seq(root / "bin", root / "usr" / "bin").map { pfx => pfx / "echo" }
+        val possiblePaths = Seq(root / "bin", root / "usr/bin").map { pfx => pfx / "echo" }
         val res = proc("which", "echo").call()
         val echoRoot = Path(res.out.text().trim())
         assert(possiblePaths.contains(echoRoot))
@@ -193,7 +193,7 @@ object SubprocessTests extends TestSuite {
       }
       test("jarTf") {
         // This was the original repro for the multi-chunk concurrency bugs
-        val jarFile = os.pwd / "os" / "test" / "resources" / "misc" / "out.jar"
+        val jarFile = os.pwd / "os/test/resources/misc/out.jar"
         assert(TestUtil.eqIgnoreNewlineStyle(
           os.proc("jar", "-tf", jarFile).call().out.text(),
           """META-INF/MANIFEST.MF
@@ -221,7 +221,7 @@ object SubprocessTests extends TestSuite {
 
     test("fileCustomWorkingDir") {
       if (Unix()) {
-        val output = proc(scriptFolder / "misc" / "echo_with_wd", "HELLO").call(cwd = root / "usr")
+        val output = proc(scriptFolder / "misc/echo_with_wd", "HELLO").call(cwd = root / "usr")
         assert(output.out.lines() == Seq("HELLO /usr"))
       }
     }

--- a/os/watch/test/src/WatchTests.scala
+++ b/os/watch/test/src/WatchTests.scala
@@ -75,7 +75,7 @@ object WatchTests extends TestSuite with TestSuite.Retries {
         Set(os.sub / "my-new-folder")
       )
 
-      checkFileManglingChanges(wd / "my-new-folder" / "test")
+      checkFileManglingChanges(wd / "my-new-folder/test")
 
       locally {
         val expectedChanges = if (isWin) Set(
@@ -85,10 +85,10 @@ object WatchTests extends TestSuite with TestSuite.Retries {
         else Set(
           os.sub / "folder2",
           os.sub / "folder3",
-          os.sub / "folder3" / "nestedA",
-          os.sub / "folder3" / "nestedA" / "a.txt",
-          os.sub / "folder3" / "nestedB",
-          os.sub / "folder3" / "nestedB" / "b.txt"
+          os.sub / "folder3/nestedA",
+          os.sub / "folder3/nestedA/a.txt",
+          os.sub / "folder3/nestedB",
+          os.sub / "folder3/nestedB/b.txt"
         )
         checkChanges(
           os.move(wd / "folder2", wd / "folder3"),
@@ -100,10 +100,10 @@ object WatchTests extends TestSuite with TestSuite.Retries {
         os.copy(wd / "folder3", wd / "folder4"),
         Set(
           os.sub / "folder4",
-          os.sub / "folder4" / "nestedA",
-          os.sub / "folder4" / "nestedA" / "a.txt",
-          os.sub / "folder4" / "nestedB",
-          os.sub / "folder4" / "nestedB" / "b.txt"
+          os.sub / "folder4/nestedA",
+          os.sub / "folder4/nestedA/a.txt",
+          os.sub / "folder4/nestedB",
+          os.sub / "folder4/nestedB/b.txt"
         )
       )
 
@@ -111,15 +111,15 @@ object WatchTests extends TestSuite with TestSuite.Retries {
         os.remove.all(wd / "folder4"),
         Set(
           os.sub / "folder4",
-          os.sub / "folder4" / "nestedA",
-          os.sub / "folder4" / "nestedA" / "a.txt",
-          os.sub / "folder4" / "nestedB",
-          os.sub / "folder4" / "nestedB" / "b.txt"
+          os.sub / "folder4/nestedA",
+          os.sub / "folder4/nestedA/a.txt",
+          os.sub / "folder4/nestedB",
+          os.sub / "folder4/nestedB/b.txt"
         )
       )
 
-      checkFileManglingChanges(wd / "folder3" / "nestedA" / "double-nested-file")
-      checkFileManglingChanges(wd / "folder3" / "nestedB" / "double-nested-file")
+      checkFileManglingChanges(wd / "folder3/nestedA/double-nested-file")
+      checkFileManglingChanges(wd / "folder3/nestedB/double-nested-file")
 
       checkChanges(
         os.symlink(wd / "newlink", wd / "doesntexist"),
@@ -132,13 +132,13 @@ object WatchTests extends TestSuite with TestSuite.Retries {
       )
 
       checkChanges(
-        os.hardlink(wd / "newlink3", wd / "folder3" / "nestedA" / "a.txt"),
+        os.hardlink(wd / "newlink3", wd / "folder3/nestedA/a.txt"),
         System.getProperty("os.name") match {
           case "Mac OS X" =>
             Set(
               os.sub / "newlink3",
-              os.sub / "folder3" / "nestedA",
-              os.sub / "folder3" / "nestedA" / "a.txt"
+              os.sub / "folder3/nestedA",
+              os.sub / "folder3/nestedA/a.txt"
             )
           case _ => Set(os.sub / "newlink3")
         }


### PR DESCRIPTION
Both test suite and docs. We leave those in `PathTests` unchanged, since that file intentionally contains a mix of different concise and verbose paths for testing purposes, and we also leave a handful of examples of verbose paths in the docs to demonstrate it's possible. Otherwise everywhere uses the concise path syntax