### PR TITLE
Propagate content length from filesystem through `geny.Writable` and `os.Source`

### DIFF
--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -534,8 +534,10 @@ trait ReadablePath {
  */
 class Path private[os] (val wrapped: java.nio.file.Path)
     extends FilePath with ReadablePath with BasePathImpl {
-  def toSource: SeekableSource =
-    new SeekableSource.ChannelSource(java.nio.file.Files.newByteChannel(wrapped))
+  def toSource: SeekableSource = new SeekableSource.ChannelLengthSource(
+    java.nio.file.Files.newByteChannel(wrapped),
+    java.nio.file.Files.size(wrapped)
+  )
 
   require(wrapped.isAbsolute || Path.driveRelative(wrapped), s"$wrapped is not an absolute path")
   def root = Option(wrapped.getRoot).map(_.toString).getOrElse("")

--- a/os/src/ReadWriteOps.scala
+++ b/os/src/ReadWriteOps.scala
@@ -247,6 +247,7 @@ object read extends Function1[ReadablePath, String] {
 
   object stream extends Function1[ReadablePath, geny.Readable] {
     def apply(p: ReadablePath): geny.Readable = new geny.Readable {
+      override def contentLength: Option[Long] = p.toSource.contentLength
       def readBytesThrough[T](f: java.io.InputStream => T): T = {
         val is = p.getInputStream
         try f(is)

--- a/os/src/Source.scala
+++ b/os/src/Source.scala
@@ -66,6 +66,8 @@ object Source extends WritableLowPri {
 
   implicit class WritableSource[T](s: T)(implicit f: T => geny.Writable) extends Source {
     val writable = f(s)
+
+    override def contentLength: Option[Long] = writable.contentLength
     def getHandle() = Left(writable)
   }
 }

--- a/os/src/Source.scala
+++ b/os/src/Source.scala
@@ -115,4 +115,9 @@ object SeekableSource {
   implicit class ChannelSource(cn: SeekableByteChannel) extends SeekableSource {
     def getHandle() = Right(cn)
   }
+  class ChannelLengthSource(cn: SeekableByteChannel, length: Long) extends SeekableSource {
+    def getHandle() = Right(cn)
+
+    override def contentLength: Option[Long] = Some(length)
+  }
 }

--- a/os/test/src/SourceTests.scala
+++ b/os/test/src/SourceTests.scala
@@ -11,6 +11,11 @@ object SourceTests extends TestSuite {
       // length is taken from the filesystem at the moment at which `.toSource` is called
       (wd / "folder1/one.txt").toSource.contentLength ==> Some(22)
       (wd / "File.txt").toSource.contentLength ==> Some(8)
+
+      // Make sure the `Writable` returned by `os.read.stream` propagates the content length
+      os.read.stream(wd / "folder1/one.txt").contentLength ==> Some(22)
+      // Even when converted to an `os.Source`
+      (os.read.stream(wd / "folder1/one.txt"): os.Source).contentLength ==> Some(22)
     }
   }
 }

--- a/os/test/src/SourceTests.scala
+++ b/os/test/src/SourceTests.scala
@@ -1,0 +1,16 @@
+package test.os
+import utest.{assert => _, _}
+
+object SourceTests extends TestSuite {
+
+  val tests = Tests {
+    test("contentMetadata") - TestUtil.prep { wd =>
+      // content type for all files is just treated as application/octet-stream,
+      // we do not do any clever mime-type inference or guessing
+      (wd / "folder1/one.txt").toSource.httpContentType ==> Some("application/octet-stream")
+      // length is taken from the filesystem at the moment at which `.toSource` is called
+      (wd / "folder1/one.txt").toSource.contentLength ==> Some(22)
+      (wd / "File.txt").toSource.contentLength ==> Some(8)
+    }
+  }
+}


### PR DESCRIPTION
This means downstream libraries like Requests-Scala or Cask can properly set the content length when handling `os.read.stream`s and similar values in their HTTP requests or responses

Noticed the lack of this when uploading to github failed in https://github.com/com-lihaoyi/mill/pull/3686 due to the lack of content length header in the upload

Covered by unit tests