### PR TITLE
Fixed typo on `Readme.adoc`

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -1341,7 +1341,7 @@ os.zip(
 This will include only `.txt` files, excluding any `.log` files and anything inside
 the `temp` folder.
 
-==== `oz.zip.stream`
+==== `os.zip.stream`
 
 You can use `os.zip.stream` to write the final zip to an `OutputStream` rather than a
 concrete `os.Path`. `os.zip.stream` returns a `geny.Writable`, which has a `writeBytesToStream`
@@ -1393,7 +1393,7 @@ os.unzip(
 )
 ----
 
-===== `oz.unzip.list`
+===== `os.unzip.list`
 You can list the contents of the zip file without extracting them:
 
 [source,scala]
@@ -1403,7 +1403,7 @@ os.unzip.list(os.Path("/path/to/archive.zip"))
 
 This will print all the file paths contained in the zip archive.
 
-==== `oz.unzip.stream`
+==== `os.unzip.stream`
 
 You can unzip a zip file from any arbitrary `java.io.InputStream` containing its binary data
 using the `os.unzip.stream` method:


### PR DESCRIPTION
I found some typos while trying new ZIP APIs (thank you!).

Seems like `oz` should be `os`.