### PR TITLE
Add flag to register shutdown hooks for `os.call` and `os.spawn` APIs, overhaul `destroy` APIs

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -1727,7 +1727,7 @@ os.call(cmd: os.Shellable,
         check: Boolean = true,
         propagateEnv: Boolean = true,
         shutdownGracePeriod: Long = 100,
-        shutdownHook: Boolean = true): os.CommandResult
+        destroyOnExit: Boolean = true): os.CommandResult
 ----
 
 _Also callable via `os.proc(cmd).call(...)`_
@@ -1857,7 +1857,7 @@ os.spawn(cmd: os.Shellable,
          mergeErrIntoOut: Boolean = false,
          propagateEnv: Boolean = true,
          shutdownGracePeriod: Long = 100,
-         shutdownHook: Boolean = true): os.SubProcess
+         destroyOnExit: Boolean = true): os.SubProcess
 ----
 
 _Also callable via `os.proc(cmd).spawn(...)`_

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -1725,7 +1725,9 @@ os.call(cmd: os.Shellable,
         mergeErrIntoOut: Boolean = false,
         timeout: Long = Long.MaxValue,
         check: Boolean = true,
-        propagateEnv: Boolean = true): os.CommandResult
+        propagateEnv: Boolean = true,
+        shutdownGracePeriod: Long = 100,
+        shutdownHook: Boolean = false): os.CommandResult
 ----
 
 _Also callable via `os.proc(cmd).call(...)`_
@@ -1853,7 +1855,9 @@ os.spawn(cmd: os.Shellable,
          stdout: os.ProcessOutput = os.Pipe,
          stderr: os.ProcessOutput = os.Pipe,
          mergeErrIntoOut: Boolean = false,
-         propagateEnv: Boolean = true): os.SubProcess
+         propagateEnv: Boolean = true,
+         shutdownGracePeriod: Long = 100,
+         shutdownHook: Boolean = false): os.SubProcess
 ----
 
 _Also callable via `os.proc(cmd).spawn(...)`_

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -1727,7 +1727,7 @@ os.call(cmd: os.Shellable,
         check: Boolean = true,
         propagateEnv: Boolean = true,
         shutdownGracePeriod: Long = 100,
-        shutdownHook: Boolean = false): os.CommandResult
+        shutdownHook: Boolean = true): os.CommandResult
 ----
 
 _Also callable via `os.proc(cmd).call(...)`_
@@ -1857,7 +1857,7 @@ os.spawn(cmd: os.Shellable,
          mergeErrIntoOut: Boolean = false,
          propagateEnv: Boolean = true,
          shutdownGracePeriod: Long = 100,
-         shutdownHook: Boolean = false): os.SubProcess
+         shutdownHook: Boolean = true): os.SubProcess
 ----
 
 _Also callable via `os.proc(cmd).spawn(...)`_

--- a/build.sc
+++ b/build.sc
@@ -171,13 +171,21 @@ object os extends Module {
       def forkEnv = super.forkEnv() ++ Map(
         "TEST_JAR_WRITER_ASSEMBLY" -> testJarWriter.assembly().path.toString,
         "TEST_JAR_READER_ASSEMBLY" -> testJarReader.assembly().path.toString,
-        "TEST_JAR_EXIT_ASSEMBLY" -> testJarExit.assembly().path.toString
+        "TEST_JAR_EXIT_ASSEMBLY" -> testJarExit.assembly().path.toString,
+        "TEST_SPAWN_EXIT_HOOK_ASSEMBLY" -> testSpawnExitHook.assembly().path.toString,
+        "TEST_SPAWN_EXIT_HOOK_ASSEMBLY2" -> testSpawnExitHook2.assembly().path.toString
       )
 
       object testJarWriter extends JavaModule
       object testJarReader extends JavaModule
       object testJarExit extends JavaModule
+      object testSpawnExitHook extends ScalaModule{
+        def scalaVersion = OsJvmModule.this.scalaVersion()
+        def moduleDeps = Seq(OsJvmModule.this)
+      }
+      object testSpawnExitHook2 extends JavaModule
     }
+
     object nohometest extends ScalaTests with OsLibTestModule
   }
 

--- a/os/src/ProcessOps.scala
+++ b/os/src/ProcessOps.scala
@@ -13,20 +13,20 @@ object call {
    * @see [[os.proc.call]]
    */
   def apply(
-             cmd: Shellable,
-             env: Map[String, String] = null,
-             // Make sure `cwd` only comes after `env`, so `os.call("foo", path)` is a compile error
-             // since the correct syntax is `os.call(("foo", path))`
-             cwd: Path = null,
-             stdin: ProcessInput = Pipe,
-             stdout: ProcessOutput = Pipe,
-             stderr: ProcessOutput = os.Inherit,
-             mergeErrIntoOut: Boolean = false,
-             timeout: Long = -1,
-             check: Boolean = true,
-             propagateEnv: Boolean = true,
-             shutdownGracePeriod: Long = 100,
-             shutdownHook: Boolean = false
+      cmd: Shellable,
+      env: Map[String, String] = null,
+      // Make sure `cwd` only comes after `env`, so `os.call("foo", path)` is a compile error
+      // since the correct syntax is `os.call(("foo", path))`
+      cwd: Path = null,
+      stdin: ProcessInput = Pipe,
+      stdout: ProcessOutput = Pipe,
+      stderr: ProcessOutput = os.Inherit,
+      mergeErrIntoOut: Boolean = false,
+      timeout: Long = -1,
+      check: Boolean = true,
+      propagateEnv: Boolean = true,
+      shutdownGracePeriod: Long = 100,
+      shutdownHook: Boolean = false
   ): CommandResult = {
     os.proc(cmd).call(
       cwd = cwd,
@@ -186,18 +186,18 @@ case class proc(command: Shellable*) {
    *       issued. Check the documentation for your JDK's `Process.destroy`.
    */
   def call(
-            cwd: Path = null,
-            env: Map[String, String] = null,
-            stdin: ProcessInput = Pipe,
-            stdout: ProcessOutput = Pipe,
-            stderr: ProcessOutput = os.Inherit,
-            mergeErrIntoOut: Boolean = false,
-            timeout: Long = -1,
-            check: Boolean = true,
-            propagateEnv: Boolean = true,
-            // this cannot be next to `timeout` as this will introduce a bin-compat break (default arguments are numbered in the bytecode)
-            shutdownGracePeriod: Long = 100,
-            shutdownHook: Boolean = false
+      cwd: Path = null,
+      env: Map[String, String] = null,
+      stdin: ProcessInput = Pipe,
+      stdout: ProcessOutput = Pipe,
+      stderr: ProcessOutput = os.Inherit,
+      mergeErrIntoOut: Boolean = false,
+      timeout: Long = -1,
+      check: Boolean = true,
+      propagateEnv: Boolean = true,
+      // this cannot be next to `timeout` as this will introduce a bin-compat break (default arguments are numbered in the bytecode)
+      shutdownGracePeriod: Long = 100,
+      shutdownHook: Boolean = false
   ): CommandResult = {
 
     val chunks = new java.util.concurrent.ConcurrentLinkedQueue[Either[geny.Bytes, geny.Bytes]]
@@ -327,7 +327,7 @@ case class proc(command: Shellable*) {
         override def run(): Unit = {
           while (proc.wrapped.isAlive) Thread.sleep(1)
           try Runtime.getRuntime().removeShutdownHook(t)
-          catch{case e: Throwable => /*do nothing*/}
+          catch { case e: Throwable => /*do nothing*/ }
         }
       }
     )

--- a/os/src/ProcessOps.scala
+++ b/os/src/ProcessOps.scala
@@ -55,7 +55,7 @@ object call {
       timeout: Long,
       check: Boolean,
       propagateEnv: Boolean,
-      timeoutGracePeriod: Long,
+      timeoutGracePeriod: Long
   ): CommandResult = {
     call(
       cmd = cmd,
@@ -248,17 +248,17 @@ case class proc(command: Shellable*) {
   )
 
   private[os] def call(
-                        cwd: Path,
-                        env: Map[String, String],
-                        stdin: ProcessInput,
-                        stdout: ProcessOutput,
-                        stderr: ProcessOutput,
-                        mergeErrIntoOut: Boolean,
-                        timeout: Long,
-                        check: Boolean,
-                        propagateEnv: Boolean,
-                        timeoutGracePeriod: Long
-                      ): CommandResult = call(
+      cwd: Path,
+      env: Map[String, String],
+      stdin: ProcessInput,
+      stdout: ProcessOutput,
+      stderr: ProcessOutput,
+      mergeErrIntoOut: Boolean,
+      timeout: Long,
+      check: Boolean,
+      propagateEnv: Boolean,
+      timeoutGracePeriod: Long
+  ): CommandResult = call(
     cwd,
     env,
     stdin,
@@ -271,7 +271,6 @@ case class proc(command: Shellable*) {
     timeoutGracePeriod,
     shutdownHook = false
   )
-
 
   /**
    * The most flexible of the [[os.proc]] calls, `os.proc.spawn` simply configures
@@ -323,7 +322,7 @@ case class proc(command: Shellable*) {
     lazy val shutdownHookMonitorThread = shutdownHookThread.map(t =>
       new Thread("subprocess-shutdown-hook-monitor") {
         override def run(): Unit = {
-          while(proc.wrapped.isAlive) Thread.sleep(1)
+          while (proc.wrapped.isAlive) Thread.sleep(1)
           Runtime.getRuntime().removeShutdownHook(t)
         }
       }
@@ -349,19 +348,25 @@ case class proc(command: Shellable*) {
   }
 
   def spawn(
-             cwd: Path,
-             env: Map[String, String],
-             stdin: ProcessInput,
-             stdout: ProcessOutput,
-             stderr: ProcessOutput,
-             mergeErrIntoOut: Boolean,
-             propagateEnv: Boolean
-           ): SubProcess = spawn(
-    cwd = cwd, env = env, stdin = stdin, stdout = stdout, stderr = stderr,
+      cwd: Path,
+      env: Map[String, String],
+      stdin: ProcessInput,
+      stdout: ProcessOutput,
+      stderr: ProcessOutput,
+      mergeErrIntoOut: Boolean,
+      propagateEnv: Boolean
+  ): SubProcess = spawn(
+    cwd = cwd,
+    env = env,
+    stdin = stdin,
+    stdout = stdout,
+    stderr = stderr,
     mergeErrIntoOut = mergeErrIntoOut,
     propagateEnv = propagateEnv,
-    shutdownGracePeriod = 100, shutdownHook = false
+    shutdownGracePeriod = 100,
+    shutdownHook = false
   )
+
   /**
    * Pipes the output of this process into the input of the [[next]] process. Returns a
    * [[ProcGroup]] containing both processes, which you can then either execute or

--- a/os/src/ProcessOps.scala
+++ b/os/src/ProcessOps.scala
@@ -26,7 +26,7 @@ object call {
       check: Boolean = true,
       propagateEnv: Boolean = true,
       shutdownGracePeriod: Long = 100,
-      shutdownHook: Boolean = false
+      shutdownHook: Boolean = true
   ): CommandResult = {
     os.proc(cmd).call(
       cwd = cwd,
@@ -90,7 +90,7 @@ object spawn {
       mergeErrIntoOut: Boolean = false,
       propagateEnv: Boolean = true,
       shutdownGracePeriod: Long = 100,
-      shutdownHook: Boolean = false
+      shutdownHook: Boolean = true
   ): SubProcess = {
     os.proc(cmd).spawn(
       cwd = cwd,
@@ -197,7 +197,7 @@ case class proc(command: Shellable*) {
       propagateEnv: Boolean = true,
       // this cannot be next to `timeout` as this will introduce a bin-compat break (default arguments are numbered in the bytecode)
       shutdownGracePeriod: Long = 100,
-      shutdownHook: Boolean = false
+      shutdownHook: Boolean = true
   ): CommandResult = {
 
     val chunks = new java.util.concurrent.ConcurrentLinkedQueue[Either[geny.Bytes, geny.Bytes]]
@@ -294,7 +294,7 @@ case class proc(command: Shellable*) {
       mergeErrIntoOut: Boolean = false,
       propagateEnv: Boolean = true,
       shutdownGracePeriod: Long = 100,
-      shutdownHook: Boolean = false
+      shutdownHook: Boolean = true
   ): SubProcess = {
 
     val cmdChunks = commandChunks

--- a/os/src/ProcessOps.scala
+++ b/os/src/ProcessOps.scala
@@ -42,6 +42,8 @@ object call {
       destroyOnExit = destroyOnExit
     )
   }
+
+  // Bincompat Forwarder
   def apply(
       cmd: Shellable,
       env: Map[String, String],
@@ -104,6 +106,8 @@ object spawn {
       destroyOnExit = destroyOnExit
     )
   }
+
+  // Bincompat Forwarder
   def apply(
       cmd: Shellable,
       // Make sure `cwd` only comes after `env`, so `os.spawn("foo", path)` is a compile error
@@ -250,6 +254,7 @@ case class proc(command: Shellable*) {
     shutdownGracePeriod = 100
   )
 
+  // Bincompat Forwarder
   private[os] def call(
       cwd: Path,
       env: Map[String, String],
@@ -351,6 +356,7 @@ case class proc(command: Shellable*) {
     proc
   }
 
+  // Bincompat Forwarder
   def spawn(
       cwd: Path,
       env: Map[String, String],

--- a/os/src/ProcessOps.scala
+++ b/os/src/ProcessOps.scala
@@ -26,7 +26,7 @@ object call {
       check: Boolean = true,
       propagateEnv: Boolean = true,
       shutdownGracePeriod: Long = 100,
-      shutdownHook: Boolean = true
+      destroyOnExit: Boolean = true
   ): CommandResult = {
     os.proc(cmd).call(
       cwd = cwd,
@@ -39,7 +39,7 @@ object call {
       check = check,
       propagateEnv = propagateEnv,
       shutdownGracePeriod = shutdownGracePeriod,
-      shutdownHook = shutdownHook
+      destroyOnExit = destroyOnExit
     )
   }
   def apply(
@@ -69,7 +69,7 @@ object call {
       check = check,
       propagateEnv = propagateEnv,
       shutdownGracePeriod = timeoutGracePeriod,
-      shutdownHook = false
+      destroyOnExit = false
     )
   }
 }
@@ -90,7 +90,7 @@ object spawn {
       mergeErrIntoOut: Boolean = false,
       propagateEnv: Boolean = true,
       shutdownGracePeriod: Long = 100,
-      shutdownHook: Boolean = true
+      destroyOnExit: Boolean = true
   ): SubProcess = {
     os.proc(cmd).spawn(
       cwd = cwd,
@@ -101,7 +101,7 @@ object spawn {
       mergeErrIntoOut = mergeErrIntoOut,
       propagateEnv = propagateEnv,
       shutdownGracePeriod = shutdownGracePeriod,
-      shutdownHook = shutdownHook
+      destroyOnExit = destroyOnExit
     )
   }
   def apply(
@@ -126,7 +126,7 @@ object spawn {
       mergeErrIntoOut = mergeErrIntoOut,
       propagateEnv = propagateEnv,
       shutdownGracePeriod = 100,
-      shutdownHook = false
+      destroyOnExit = false
     )
   }
 }
@@ -197,7 +197,7 @@ case class proc(command: Shellable*) {
       propagateEnv: Boolean = true,
       // this cannot be next to `timeout` as this will introduce a bin-compat break (default arguments are numbered in the bytecode)
       shutdownGracePeriod: Long = 100,
-      shutdownHook: Boolean = true
+      destroyOnExit: Boolean = true
   ): CommandResult = {
 
     val chunks = new java.util.concurrent.ConcurrentLinkedQueue[Either[geny.Bytes, geny.Bytes]]
@@ -272,7 +272,7 @@ case class proc(command: Shellable*) {
     check,
     propagateEnv,
     timeoutGracePeriod,
-    shutdownHook = false
+    destroyOnExit = false
   )
 
   /**
@@ -294,7 +294,7 @@ case class proc(command: Shellable*) {
       mergeErrIntoOut: Boolean = false,
       propagateEnv: Boolean = true,
       shutdownGracePeriod: Long = 100,
-      shutdownHook: Boolean = true
+      destroyOnExit: Boolean = true
   ): SubProcess = {
 
     val cmdChunks = commandChunks
@@ -317,7 +317,7 @@ case class proc(command: Shellable*) {
     )
 
     lazy val shutdownHookThread =
-      if (!shutdownHook) None
+      if (!destroyOnExit) None
       else Some(new Thread("subprocess-shutdown-hook") {
         override def run(): Unit = proc.destroy(shutdownGracePeriod)
       })
@@ -368,7 +368,7 @@ case class proc(command: Shellable*) {
     mergeErrIntoOut = mergeErrIntoOut,
     propagateEnv = propagateEnv,
     shutdownGracePeriod = 100,
-    shutdownHook = false
+    destroyOnExit = false
   )
 
   /**

--- a/os/src/SubProcess.scala
+++ b/os/src/SubProcess.scala
@@ -143,6 +143,7 @@ class SubProcess(
   /**
    * Attempt to destroy the subprocess (gently), via the underlying JVM APIs
    */
+  @deprecated("Use destroy(shutdownGracePeriod = Long.MaxValue)")
   def destroy(): Unit = destroy(shutdownGracePeriod = Long.MaxValue)
 
   /**

--- a/os/src/SubProcess.scala
+++ b/os/src/SubProcess.scala
@@ -111,11 +111,17 @@ class SubProcess(
     val shutdownHookMonitorThread: Option[Thread]
 ) extends ProcessLike {
   def this(
-                    wrapped: java.lang.Process,
-                    inputPumperThread: Option[Thread],
-                    outputPumperThread: Option[Thread],
-                    errorPumperThread: Option[Thread]) = this(
-    wrapped, inputPumperThread, outputPumperThread, errorPumperThread, 100, None
+      wrapped: java.lang.Process,
+      inputPumperThread: Option[Thread],
+      outputPumperThread: Option[Thread],
+      errorPumperThread: Option[Thread]
+  ) = this(
+    wrapped,
+    inputPumperThread,
+    outputPumperThread,
+    errorPumperThread,
+    100,
+    None
   )
   val stdin: SubProcess.InputStream = new SubProcess.InputStream(wrapped.getOutputStream)
   val stdout: SubProcess.OutputStream = new SubProcess.OutputStream(wrapped.getInputStream)
@@ -145,7 +151,7 @@ class SubProcess(
   def destroyForcibly(shutdownGracePeriod: Long = this.shutdownGracePeriod): Unit = {
     val now = System.currentTimeMillis()
 
-    while(wrapped.isAlive && System.currentTimeMillis() - now < shutdownGracePeriod){
+    while (wrapped.isAlive && System.currentTimeMillis() - now < shutdownGracePeriod) {
       Thread.sleep(1)
     }
 

--- a/os/src/SubProcess.scala
+++ b/os/src/SubProcess.scala
@@ -157,7 +157,10 @@ class SubProcess(
    *                            (i.e. force exit immediately) or Long.MaxValue (i.e. never force exit)
    *                            or anything in between. Typically defaults to 100 milliseconds
    */
-  def destroy(shutdownGracePeriod: Long = this.shutdownGracePeriod, async: Boolean = false): Unit = {
+  def destroy(
+      shutdownGracePeriod: Long = this.shutdownGracePeriod,
+      async: Boolean = false
+  ): Unit = {
     wrapped.destroy()
     if (!async) {
       val now = System.currentTimeMillis()

--- a/os/test/src-jvm/SpawningSubprocessesNewTests.scala
+++ b/os/test/src-jvm/SpawningSubprocessesNewTests.scala
@@ -153,7 +153,7 @@ object SpawningSubprocessesNewTests extends TestSuite {
         sha.stdout.trim() ==> s"${ExampleResourcess.RemoteReadme.gzip6ShaSum256}  -"
       }
     }
-    test("spawn callback")  - prep { wd =>
+    test("spawn callback") - prep { wd =>
       if (TestUtil.isInstalled("echo") && Unix()) {
         val output: mutable.Buffer[String] = mutable.Buffer()
         val sub = os.spawn(
@@ -174,16 +174,16 @@ object SpawningSubprocessesNewTests extends TestSuite {
       .open(p.toNIO, util.EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE))
       .tryLock()
     def waitForLockTaken(p: os.Path) = {
-      while({
+      while ({
         val waitLock = tryLock(p)
         if (waitLock != null) {
           waitLock.release()
           true
-        }else false
+        } else false
       }) Thread.sleep(1)
     }
 
-    test("destroy"){
+    test("destroy") {
       val temp1 = os.temp()
       val sub1 = os.spawn((sys.env("TEST_SPAWN_EXIT_HOOK_ASSEMBLY"), temp1))
       waitForLockTaken(temp1)
@@ -197,8 +197,7 @@ object SpawningSubprocessesNewTests extends TestSuite {
       assert(sub2.isAlive())
     }
 
-    test("spawnExitHook"){
-
+    test("spawnExitHook") {
 
       val temp = os.temp()
       val lock0 = tryLock(temp)

--- a/os/test/src-jvm/SpawningSubprocessesTests.scala
+++ b/os/test/src-jvm/SpawningSubprocessesTests.scala
@@ -147,23 +147,23 @@ object SpawningSubprocessesTests extends TestSuite {
       }
     }
     test("spawn callback") {
-        test - prep { wd =>
-          if (TestUtil.isInstalled("echo") && Unix()) {
-            val output: mutable.Buffer[String] = mutable.Buffer()
-            val sub = os.proc("echo", "output")
-              .spawn(stdout =
-                ProcessOutput((bytes, count) => output += new String(bytes, 0, count))
-              )
-            val finished = sub.join(5000)
-            sub.wrapped.getOutputStream().flush()
-            assert(finished)
-            assert(sub.exitCode() == 0)
-            val expectedOutput = "output\n"
-            val actualOutput = output.mkString("")
-            assert(actualOutput == expectedOutput)
-            sub.destroy()
-          }
+      test - prep { wd =>
+        if (TestUtil.isInstalled("echo") && Unix()) {
+          val output: mutable.Buffer[String] = mutable.Buffer()
+          val sub = os.proc("echo", "output")
+            .spawn(stdout =
+              ProcessOutput((bytes, count) => output += new String(bytes, 0, count))
+            )
+          val finished = sub.join(5000)
+          sub.wrapped.getOutputStream().flush()
+          assert(finished)
+          assert(sub.exitCode() == 0)
+          val expectedOutput = "output\n"
+          val actualOutput = output.mkString("")
+          assert(actualOutput == expectedOutput)
+          sub.destroy()
         }
       }
+    }
   }
 }

--- a/os/test/src-jvm/SpawningSubprocessesTests.scala
+++ b/os/test/src-jvm/SpawningSubprocessesTests.scala
@@ -11,143 +11,142 @@ import utest._
 object SpawningSubprocessesTests extends TestSuite {
 
   def tests = Tests {
-    test("proc") {
-      test("call") {
-        test - prep { wd =>
-          if (Unix()) {
-            val res = os.proc("ls", wd / "folder2").call()
+    test("call") {
+      test - prep { wd =>
+        if (Unix()) {
+          val res = os.proc("ls", wd / "folder2").call()
 
-            res.exitCode ==> 0
+          res.exitCode ==> 0
 
-            res.out.text() ==>
-              """nestedA
-                |nestedB
-                |""".stripMargin
+          res.out.text() ==>
+            """nestedA
+              |nestedB
+              |""".stripMargin
 
-            res.out.trim() ==>
-              """nestedA
-                |nestedB""".stripMargin
+          res.out.trim() ==>
+            """nestedA
+              |nestedB""".stripMargin
 
-            res.out.lines() ==> Seq(
-              "nestedA",
-              "nestedB"
-            )
+          res.out.lines() ==> Seq(
+            "nestedA",
+            "nestedB"
+          )
 
-            res.out.bytes
+          res.out.bytes
 
-            val thrown = intercept[os.SubprocessException] {
-              os.proc("ls", "doesnt-exist").call(cwd = wd)
-            }
-
-            assert(thrown.result.exitCode != 0)
-
-            val fail = os.proc("ls", "doesnt-exist").call(cwd = wd, check = false, stderr = os.Pipe)
-
-            assert(fail.exitCode != 0)
-
-            fail.out.text() ==> ""
-
-            assert(fail.err.text().contains("No such file or directory"))
-
-            // You can pass in data to a subprocess' stdin
-            val hash = os.proc("shasum", "-a", "256").call(stdin = "Hello World")
-            hash.out.trim() ==> "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e  -"
-
-            // Taking input from a file and directing output to another file
-            os.proc("base64").call(stdin = wd / "File.txt", stdout = wd / "File.txt.b64")
-
-            os.read(wd / "File.txt.b64") ==> "SSBhbSBjb3c=\n"
-
-            if (false) {
-              os.proc("vim").call(stdin = os.Inherit, stdout = os.Inherit, stderr = os.Inherit)
-            }
+          val thrown = intercept[os.SubprocessException] {
+            os.proc("ls", "doesnt-exist").call(cwd = wd)
           }
-        }
-        test - prep { wd =>
-          if (Unix()) {
-            val ex = intercept[os.SubprocessException] {
-              os.proc("bash", "-c", "echo 123; sleep 10; echo 456")
-                .call(timeout = 2000)
-            }
 
-            ex.result.out.trim() ==> "123"
+          assert(thrown.result.exitCode != 0)
+
+          val fail = os.proc("ls", "doesnt-exist").call(cwd = wd, check = false, stderr = os.Pipe)
+
+          assert(fail.exitCode != 0)
+
+          fail.out.text() ==> ""
+
+          assert(fail.err.text().contains("No such file or directory"))
+
+          // You can pass in data to a subprocess' stdin
+          val hash = os.proc("shasum", "-a", "256").call(stdin = "Hello World")
+          hash.out.trim() ==> "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e  -"
+
+          // Taking input from a file and directing output to another file
+          os.proc("base64").call(stdin = wd / "File.txt", stdout = wd / "File.txt.b64")
+
+          os.read(wd / "File.txt.b64") ==> "SSBhbSBjb3c=\n"
+
+          if (false) {
+            os.proc("vim").call(stdin = os.Inherit, stdout = os.Inherit, stderr = os.Inherit)
           }
         }
       }
-      test("stream") {
-        test - prep { wd =>
-          if (Unix()) {
-            var lineCount = 1
-            os.proc("find", ".").call(
-              cwd = wd,
-              stdout =
-                os.ProcessOutput((buf, len) => lineCount += buf.slice(0, len).count(_ == '\n'))
-            )
-            lineCount ==> 22
+      test - prep { wd =>
+        if (Unix()) {
+          val ex = intercept[os.SubprocessException] {
+            os.proc("bash", "-c", "echo 123; sleep 10; echo 456")
+              .call(timeout = 2000)
           }
-        }
-        test - prep { wd =>
-          if (Unix()) {
-            var lineCount = 1
-            os.proc("find", ".").call(
-              cwd = wd,
-              stdout = os.ProcessOutput.Readlines(line => lineCount += 1)
-            )
-            lineCount ==> 22
-          }
+
+          ex.result.out.trim() ==> "123"
         }
       }
-
-      test("spawn python") {
-        test - prep { wd =>
-          if (TestUtil.isInstalled("python") && Unix()) {
-            // Start a long-lived python process which you can communicate with
-            val sub = os.proc(
-              "python",
-              "-u",
-              "-c",
-              if (TestUtil.isPython3()) "while True: print(eval(input()))"
-              else "while True: print(eval(raw_input()))"
-            )
-              .spawn(cwd = wd)
-
-            // Sending some text to the subprocess
-            sub.stdin.write("1 + 2")
-            sub.stdin.writeLine("+ 4")
-            sub.stdin.flush()
-            sub.stdout.readLine() ==> "7"
-
-            sub.stdin.write("'1' + '2'")
-            sub.stdin.writeLine("+ '4'")
-            sub.stdin.flush()
-            sub.stdout.readLine() ==> "124"
-
-            // Sending some bytes to the subprocess
-            sub.stdin.write("1 * 2".getBytes)
-            sub.stdin.write("* 4\n".getBytes)
-            sub.stdin.flush()
-            sub.stdout.read() ==> '8'.toByte
-
-            sub.destroy()
-          }
+    }
+    test("stream") {
+      test - prep { wd =>
+        if (Unix()) {
+          var lineCount = 1
+          os.proc("find", ".").call(
+            cwd = wd,
+            stdout =
+              os.ProcessOutput((buf, len) => lineCount += buf.slice(0, len).count(_ == '\n'))
+          )
+          lineCount ==> 22
         }
       }
-      test("spawn curl") {
-        if (
-          Unix() && // shasum seems to not accept stdin on Windows
-          TestUtil.isInstalled("curl") &&
-          TestUtil.isInstalled("gzip") &&
-          TestUtil.isInstalled("shasum")
-        ) {
-          // You can chain multiple subprocess' stdin/stdout together
-          val curl =
-            os.proc("curl", "-L", ExampleResourcess.RemoteReadme.url).spawn(stderr = os.Inherit)
-          val gzip = os.proc("gzip", "-n", "-6").spawn(stdin = curl.stdout)
-          val sha = os.proc("shasum", "-a", "256").spawn(stdin = gzip.stdout)
-          sha.stdout.trim() ==> s"${ExampleResourcess.RemoteReadme.gzip6ShaSum256}  -"
+      test - prep { wd =>
+        if (Unix()) {
+          var lineCount = 1
+          os.proc("find", ".").call(
+            cwd = wd,
+            stdout = os.ProcessOutput.Readlines(line => lineCount += 1)
+          )
+          lineCount ==> 22
         }
       }
-      test("spawn callback") {
+    }
+
+    test("spawn python") {
+      test - prep { wd =>
+        if (TestUtil.isInstalled("python") && Unix()) {
+          // Start a long-lived python process which you can communicate with
+          val sub = os.proc(
+            "python",
+            "-u",
+            "-c",
+            if (TestUtil.isPython3()) "while True: print(eval(input()))"
+            else "while True: print(eval(raw_input()))"
+          )
+            .spawn(cwd = wd)
+
+          // Sending some text to the subprocess
+          sub.stdin.write("1 + 2")
+          sub.stdin.writeLine("+ 4")
+          sub.stdin.flush()
+          sub.stdout.readLine() ==> "7"
+
+          sub.stdin.write("'1' + '2'")
+          sub.stdin.writeLine("+ '4'")
+          sub.stdin.flush()
+          sub.stdout.readLine() ==> "124"
+
+          // Sending some bytes to the subprocess
+          sub.stdin.write("1 * 2".getBytes)
+          sub.stdin.write("* 4\n".getBytes)
+          sub.stdin.flush()
+          sub.stdout.read() ==> '8'.toByte
+
+          sub.destroy()
+        }
+      }
+    }
+    test("spawn curl") {
+      if (
+        Unix() && // shasum seems to not accept stdin on Windows
+        TestUtil.isInstalled("curl") &&
+        TestUtil.isInstalled("gzip") &&
+        TestUtil.isInstalled("shasum")
+      ) {
+        // You can chain multiple subprocess' stdin/stdout together
+        val curl =
+          os.proc("curl", "-L", ExampleResourcess.RemoteReadme.url).spawn(stderr = os.Inherit)
+        val gzip = os.proc("gzip", "-n", "-6").spawn(stdin = curl.stdout)
+        val sha = os.proc("shasum", "-a", "256").spawn(stdin = gzip.stdout)
+        sha.stdout.trim() ==> s"${ExampleResourcess.RemoteReadme.gzip6ShaSum256}  -"
+      }
+    }
+    test("spawn callback") {
         test - prep { wd =>
           if (TestUtil.isInstalled("echo") && Unix()) {
             val output: mutable.Buffer[String] = mutable.Buffer()
@@ -166,6 +165,5 @@ object SpawningSubprocessesTests extends TestSuite {
           }
         }
       }
-    }
   }
 }

--- a/os/test/testSpawnExitHook/src/TestSpawnExitHook.scala
+++ b/os/test/testSpawnExitHook/src/TestSpawnExitHook.scala
@@ -2,7 +2,7 @@ package test.os
 
 object TestSpawnExitHook {
   def main(args: Array[String]): Unit = {
-    os.spawn((sys.env("TEST_SPAWN_EXIT_HOOK_ASSEMBLY2"), args(0)), shutdownHook = true)
+    os.spawn((sys.env("TEST_SPAWN_EXIT_HOOK_ASSEMBLY2"), args(0)), destroyOnExit = true)
     Thread.sleep(99999)
   }
 }

--- a/os/test/testSpawnExitHook/src/TestSpawnExitHook.scala
+++ b/os/test/testSpawnExitHook/src/TestSpawnExitHook.scala
@@ -2,7 +2,14 @@ package test.os
 
 object TestSpawnExitHook {
   def main(args: Array[String]): Unit = {
-    os.spawn((sys.env("TEST_SPAWN_EXIT_HOOK_ASSEMBLY2"), args(0)), destroyOnExit = true)
+    Runtime.getRuntime.addShutdownHook(
+      new Thread(() => {
+        for (shutdownDelay <- args.lift(1)) Thread.sleep(shutdownDelay.toLong)
+        System.err.println("Shutdown Hook")
+      })
+    )
+    val cmd = (sys.env("TEST_SPAWN_EXIT_HOOK_ASSEMBLY2"), args(0))
+    os.spawn(cmd = cmd, destroyOnExit = true)
     Thread.sleep(99999)
   }
 }

--- a/os/test/testSpawnExitHook/src/TestSpawnExitHook.scala
+++ b/os/test/testSpawnExitHook/src/TestSpawnExitHook.scala
@@ -1,6 +1,6 @@
 package test.os
 
-object TestSpawnExitHook{
+object TestSpawnExitHook {
   def main(args: Array[String]): Unit = {
     os.spawn((sys.env("TEST_SPAWN_EXIT_HOOK_ASSEMBLY2"), args(0)), shutdownHook = true)
     Thread.sleep(99999)

--- a/os/test/testSpawnExitHook/src/TestSpawnExitHook.scala
+++ b/os/test/testSpawnExitHook/src/TestSpawnExitHook.scala
@@ -1,0 +1,8 @@
+package test.os
+
+object TestSpawnExitHook{
+  def main(args: Array[String]): Unit = {
+    os.spawn((sys.env("TEST_SPAWN_EXIT_HOOK_ASSEMBLY2"), args(0)), shutdownHook = true)
+    Thread.sleep(99999)
+  }
+}

--- a/os/test/testSpawnExitHook2/src/TestSpawnExitHook2.java
+++ b/os/test/testSpawnExitHook2/src/TestSpawnExitHook2.java
@@ -1,0 +1,12 @@
+package test.os;
+import java.nio.file.StandardOpenOption;
+
+public class TestSpawnExitHook2{
+  public static void main(String[] args) throws Exception{
+    java.nio.channels.FileChannel.open(
+            java.nio.file.Paths.get(args[0]),
+            java.util.EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE)
+    ).lock();
+    Thread.sleep(1337000);
+  }
+}


### PR DESCRIPTION
* Backports the functionality from Mill to allow us to register shutdown hooks such that when the parent process terminates the subprocesses are shut down as well. This allows the same logic to be used consistently across all `.call` and `.spawn` invocations

* Consolidate `SubProcess#destroy` and `SubProcess#destroyForcibly` into a single `SubProcess#destroy` method which takes some default parameters, allowing the user to choose `async = true` or configure the `shutdownGracePeriod: Long`.

* The default behavior of `SubProcess#destroy` has changed to block on the subprocess actually exiting, which I think is more intuitive. The old behavior is available under `destroy(async = true)`

Best reviewed with `Hide whitespace`. Added some simple unit tests to assert the new functionality, existing unit tests should assert on existing workflows