### PR TITLE
Add compile-time validation of literal paths containing ".."

### DIFF
--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -26,12 +26,14 @@ object PathChunk extends PathChunkMacros {
     val splitted = strNoTrailingSeps.split('/')
     splitted ++ Array.fill(trailingSeparatorsCount)("")
   }
-  private def reduceUps(in:Array[String]): List[String] = in.foldLeft(List.empty[String]){case (acc,x) => 
-	   acc match{
-	     case h :: t if h == ".." => x :: acc
-	     case h :: t if x == ".." => t
-	     case _ => x :: acc}
-	 }.reverse
+  private def reduceUps(in: Array[String]): List[String] =
+    in.foldLeft(List.empty[String]) { case (acc, x) =>
+      acc match {
+        case h :: t if h == ".." => x :: acc
+        case h :: t if x == ".." => t
+        case _ => x :: acc
+      }
+    }.reverse
   private[os] def segmentsFromStringLiteralValidation(literal: String): Array[String] = {
     val stringSegments = segmentsFromString(literal)
     val validSegmnts = reduceUps(validLiteralSegments(stringSegments))

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -26,10 +26,15 @@ object PathChunk extends PathChunkMacros {
     val splitted = strNoTrailingSeps.split('/')
     splitted ++ Array.fill(trailingSeparatorsCount)("")
   }
-
+  private def reduceUps(in:List[String]) = in.foldLeft(List.empty[String]){case (acc,x) => 
+	   acc match{
+	     case h :: t if h == ".." => x :: acc
+	     case h :: t if x == ".." => t
+	     case _ => x :: acc}
+	 }.reverse
   private[os] def segmentsFromStringLiteralValidation(literal: String): Array[String] = {
     val stringSegments = segmentsFromString(literal)
-    val validSegmnts = validLiteralSegments(stringSegments)
+    val validSegmnts = reduceUps(validLiteralSegments(stringSegments))
     val sanitizedLiteral = validSegmnts.mkString("/")
     if (validSegmnts.isEmpty) throw InvalidSegment(
       literal,

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -26,7 +26,7 @@ object PathChunk extends PathChunkMacros {
     val splitted = strNoTrailingSeps.split('/')
     splitted ++ Array.fill(trailingSeparatorsCount)("")
   }
-  private def reduceUps(in:List[String]) = in.foldLeft(List.empty[String]){case (acc,x) => 
+  private def reduceUps(in:Array[String]): List[String] = in.foldLeft(List.empty[String]){case (acc,x) => 
 	   acc match{
 	     case h :: t if h == ".." => x :: acc
 	     case h :: t if x == ".." => t

--- a/os/test/src-jvm/ExpectyIntegration.scala
+++ b/os/test/src-jvm/ExpectyIntegration.scala
@@ -24,7 +24,7 @@ object ExpectyIntegration extends TestSuite {
         expect(path.startsWith(os.Path("/") / "tmp"))
       }
       test("multiple args") {
-        expect(rel / "src" / ".." == rel / "src" / os.up, root / "src/.." == root / "src" / os.up)
+        expect(rel / "src" / ".." == rel / "src" / os.up, root / "src" / "../foo" == root / "src" / os.up / "foo")
       }
     }
   }

--- a/os/test/src-jvm/ExpectyIntegration.scala
+++ b/os/test/src-jvm/ExpectyIntegration.scala
@@ -14,11 +14,9 @@ object ExpectyIntegration extends TestSuite {
       }
       test("literals with [..]") {
         expect(rel / "src" / ".." == rel / "src" / os.up)
-        expect(root / "src/.." == root / "src" / os.up)
         expect(root / "src" / ".." == root / "src" / os.up)
         expect(root / "hello" / ".." / "world" == root / "hello" / os.up / "world")
         expect(root / "hello" / "../world" == root / "hello" / os.up / "world")
-        expect(root / "hello/../world" == root / "hello" / os.up / "world")
       }
       test("from issue") {
         expect(Seq(os.pwd / "foo") == Seq(os.pwd / "foo"))

--- a/os/test/src-jvm/ExpectyIntegration.scala
+++ b/os/test/src-jvm/ExpectyIntegration.scala
@@ -24,7 +24,10 @@ object ExpectyIntegration extends TestSuite {
         expect(path.startsWith(os.Path("/") / "tmp"))
       }
       test("multiple args") {
-        expect(rel / "src" / ".." == rel / "src" / os.up, root / "src" / "../foo" == root / "src" / os.up / "foo")
+        expect(
+          rel / "src" / ".." == rel / "src" / os.up,
+          root / "src" / "../foo" == root / "src" / os.up / "foo"
+        )
       }
     }
   }

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -30,20 +30,44 @@ object PathTests extends TestSuite {
 
       test("Compile errors") {
 
-        compileError("""root / "src/../foo"""").check("", nonCanonicalLiteral("src/../foo","foo"))
-        compileError("""root / "hello/../world"""").check("", nonCanonicalLiteral("hello/../world","world"))
-        compileError("""root / "src/../foo/bar"""").check("", nonCanonicalLiteral("src/../foo/bar","foo/bar"))
-        compileError("""root / "src/../foo/bar/.."""").check("", nonCanonicalLiteral("src/../foo/bar/..","foo"))
-        compileError("""root / "src/../foo/../bar/."""").check("", nonCanonicalLiteral("src/../foo/../bar/.","bar"))
-        compileError("""root / "src/foo/./.."""").check("", nonCanonicalLiteral("src/foo/./..","src"))
-        compileError("""root / "src/foo//./.."""").check("", nonCanonicalLiteral("src/foo//./..","src"))
+        compileError("""root / "src/../foo"""").check("", nonCanonicalLiteral("src/../foo", "foo"))
+        compileError("""root / "hello/../world"""").check(
+          "",
+          nonCanonicalLiteral("hello/../world", "world")
+        )
+        compileError("""root / "src/../foo/bar"""").check(
+          "",
+          nonCanonicalLiteral("src/../foo/bar", "foo/bar")
+        )
+        compileError("""root / "src/../foo/bar/.."""").check(
+          "",
+          nonCanonicalLiteral("src/../foo/bar/..", "foo")
+        )
+        compileError("""root / "src/../foo/../bar/."""").check(
+          "",
+          nonCanonicalLiteral("src/../foo/../bar/.", "bar")
+        )
+        compileError("""root / "src/foo/./.."""").check(
+          "",
+          nonCanonicalLiteral("src/foo/./..", "src")
+        )
+        compileError("""root / "src/foo//./.."""").check(
+          "",
+          nonCanonicalLiteral("src/foo//./..", "src")
+        )
 
         compileError("""root / "src/.."""").check("", removeLiteralErr("src/.."))
         compileError("""root / "src/../foo/.."""").check("", removeLiteralErr("src/../foo/.."))
         compileError("""root / "src/foo/../.."""").check("", removeLiteralErr("src/foo/../.."))
         compileError("""root / "src/foo/./../.."""").check("", removeLiteralErr("src/foo/./../.."))
-        compileError("""root / "src/./foo/./../.."""").check("", removeLiteralErr("src/./foo/./../.."))
-        compileError("""root / "src///foo/./../.."""").check("", removeLiteralErr("src///foo/./../.."))
+        compileError("""root / "src/./foo/./../.."""").check(
+          "",
+          removeLiteralErr("src/./foo/./../..")
+        )
+        compileError("""root / "src///foo/./../.."""").check(
+          "",
+          removeLiteralErr("src///foo/./../..")
+        )
 
         compileError("""root / "/" """).check("", removeLiteralErr("/"))
         compileError("""root / "/ " """).check("", nonCanonicalLiteral("/ ", " "))
@@ -54,7 +78,10 @@ object PathTests extends TestSuite {
         compileError("""root / "foo//" """).check("", nonCanonicalLiteral("foo//", "foo"))
 
         compileError("""root / "foo/bar/" """).check("", nonCanonicalLiteral("foo/bar/", "foo/bar"))
-        compileError("""root / "foo/bar//" """).check("", nonCanonicalLiteral("foo/bar//", "foo/bar"))
+        compileError("""root / "foo/bar//" """).check(
+          "",
+          nonCanonicalLiteral("foo/bar//", "foo/bar")
+        )
 
         compileError("""root / "/foo" """).check("", nonCanonicalLiteral("/foo", "foo"))
         compileError("""root / "//foo" """).check("", nonCanonicalLiteral("//foo", "foo"))


### PR DESCRIPTION
Addresses #327 

This PR adds additional validation of literal path segments containing `..`.

It throws compiletime error, suggesting canonical form of a path, when literal path is not canonical.

Eg. "../foo/../bar"   suggests  "../bar"

"foo/.." suggests removing literal 