### PR TITLE
Revert "Fix empty folder missing problem when zip files. (#330)"

### DIFF
--- a/os/test/src-jvm/SpawningSubprocessesNewTests.scala
+++ b/os/test/src-jvm/SpawningSubprocessesNewTests.scala
@@ -86,7 +86,7 @@ object SpawningSubprocessesNewTests extends TestSuite {
             stdout =
               os.ProcessOutput((buf, len) => lineCount += buf.slice(0, len).count(_ == '\n'))
           )
-          lineCount ==> 24
+          lineCount ==> 22
         }
       }
       test - prep { wd =>
@@ -97,7 +97,7 @@ object SpawningSubprocessesNewTests extends TestSuite {
             cwd = wd,
             stdout = os.ProcessOutput.Readlines(line => lineCount += 1)
           )
-          lineCount ==> 24
+          lineCount ==> 22
         }
       }
     }

--- a/os/test/src-jvm/SpawningSubprocessesTests.scala
+++ b/os/test/src-jvm/SpawningSubprocessesTests.scala
@@ -82,7 +82,7 @@ object SpawningSubprocessesTests extends TestSuite {
             stdout =
               os.ProcessOutput((buf, len) => lineCount += buf.slice(0, len).count(_ == '\n'))
           )
-          lineCount ==> 24
+          lineCount ==> 22
         }
       }
       test - prep { wd =>
@@ -92,7 +92,7 @@ object SpawningSubprocessesTests extends TestSuite {
             cwd = wd,
             stdout = os.ProcessOutput.Readlines(line => lineCount += 1)
           )
-          lineCount ==> 24
+          lineCount ==> 22
         }
       }
     }

--- a/os/test/src-jvm/ZipOpJvmTests.scala
+++ b/os/test/src-jvm/ZipOpJvmTests.scala
@@ -36,21 +36,19 @@ object ZipOpJvmTests extends TestSuite {
         dest = wd / "unzipped folder"
       )
 
-      val paths = os.walk(unzippedFolder).toList.sorted
-      val expected = List(
+      val paths = os.walk(unzippedFolder)
+      val expected = Seq(
         // Files get included in the zip root using their name
         wd / "unzipped folder/File.txt",
         wd / "unzipped folder/Multi Line.txt",
         // Folder contents get included relative to the source root
-        wd / "unzipped folder/folder1",
-        wd / "unzipped folder/folder1/one.txt",
-        wd / "unzipped folder/folder2",
-        wd / "unzipped folder/folder2/nestedA",
-        wd / "unzipped folder/folder2/nestedA/a.txt",
-        wd / "unzipped folder/folder2/nestedB",
-        wd / "unzipped folder/folder2/nestedB/b.txt"
-      ).sorted
-      assert(paths == expected)
+        wd / "unzipped folder/nestedA",
+        wd / "unzipped folder/nestedB",
+        wd / "unzipped folder/one.txt",
+        wd / "unzipped folder/nestedA/a.txt",
+        wd / "unzipped folder/nestedB/b.txt"
+      )
+      assert(paths.sorted == expected)
     }
 
     test("zipAndUnzipPreserveMtimes") - prep { wd =>

--- a/os/test/src/CheckerTests.scala
+++ b/os/test/src/CheckerTests.scala
@@ -453,9 +453,8 @@ object CheckerTests extends TestSuite {
       val unzipDir = os.unzip(zipFile, wd / "unzipped")
       os.walk(unzipDir).sorted ==> Seq(
         unzipDir / "File.txt",
-        unzipDir / "folder1/one.txt",
-        unzipDir / "folder1"
-      ).sorted
+        unzipDir / "one.txt"
+      )
     }
     test("unzip") - prepChecker { wd =>
       val zipFileName = "zipped.zip"
@@ -479,7 +478,7 @@ object CheckerTests extends TestSuite {
         source = zipFile,
         dest = wd / "unzipped"
       )
-      os.walk(unzipDir).length ==> 3
+      os.walk(unzipDir).length ==> 2
     }
   }
 }

--- a/os/test/src/OpTests.scala
+++ b/os/test/src/OpTests.scala
@@ -18,8 +18,7 @@ object OpTests extends TestSuite {
         res / "misc",
         res / "os",
         res / "File.txt",
-        res / "Multi Line.txt",
-        res / "emptyFolder"
+        res / "Multi Line.txt"
       ),
       os.list(res / "folder2").toSet == Set(
         res / "folder2/nestedA",

--- a/os/test/src/ZipOpTests.scala
+++ b/os/test/src/ZipOpTests.scala
@@ -54,10 +54,9 @@ object ZipOpTests extends TestSuite {
       val expected = Seq(
         wd / "unzipped folder/renamed-file.txt",
         wd / "unzipped folder/renamed-folder",
-        wd / "unzipped folder/renamed-folder/folder1",
-        wd / "unzipped folder/renamed-folder/folder1/one.txt"
+        wd / "unzipped folder/renamed-folder/one.txt"
       )
-      assert(paths.sorted == expected.sorted)
+      assert(paths.sorted == expected)
     }
 
     test("excludePatterns") - prep { wd =>
@@ -81,9 +80,8 @@ object ZipOpTests extends TestSuite {
         zipFile1,
         dest = wd / "zipByExcludingCertainFiles"
       )
-      val paths = os.walk(outputZipFilePath).toList.sorted
-      val expected =
-        Seq(wd / "zipByExcludingCertainFiles/File.amx").toList.sorted
+      val paths = os.walk(outputZipFilePath).sorted
+      val expected = Seq(wd / "zipByExcludingCertainFiles/File.amx")
       assert(paths == expected)
     }
 
@@ -106,8 +104,8 @@ object ZipOpTests extends TestSuite {
       // Unzip file to check for contents
       val outputZipFilePath =
         os.unzip(zipFile1, dest = wd / "zipByIncludingCertainFiles")
-      val paths = os.walk(outputZipFilePath).toSeq.sorted
-      val expected = List(wd / "zipByIncludingCertainFiles" / amxFile).sorted
+      val paths = os.walk(outputZipFilePath)
+      val expected = Seq(wd / "zipByIncludingCertainFiles" / amxFile)
       assert(paths == expected)
     }
 
@@ -126,8 +124,8 @@ object ZipOpTests extends TestSuite {
         dest = wd / "zipStreamFunction"
       )
 
-      val paths = os.walk(unzippedFolder).toSeq
-      assert(paths.sorted == Seq(unzippedFolder / "File.txt").sorted)
+      val paths = os.walk(unzippedFolder)
+      assert(paths == Seq(unzippedFolder / "File.txt"))
     }
 
     test("list") - prep { wd =>
@@ -142,10 +140,9 @@ object ZipOpTests extends TestSuite {
       )
 
       // Unzip file to a destination folder
-      val listedContents = os.unzip.list(source = wd / zipFileName).toList.sorted
+      val listedContents = os.unzip.list(source = wd / zipFileName).toSeq
 
-      val expected =
-        List(os.sub / "File.txt", os.sub / "folder1/one.txt", os.sub / "folder1").sorted
+      val expected = Seq(os.sub / "File.txt", os.sub / "one.txt")
       assert(listedContents == expected)
     }
 
@@ -170,12 +167,11 @@ object ZipOpTests extends TestSuite {
         excludePatterns = Seq(amxFile.r)
       )
 
-      val paths = os.walk(unzippedFolder).toList.sorted
-      val expected = List(
+      val paths = os.walk(unzippedFolder)
+      val expected = Seq(
         wd / "unzipAllExceptExcludingCertainFiles/File.txt",
-        wd / "unzipAllExceptExcludingCertainFiles/folder1/one.txt",
-        wd / "unzipAllExceptExcludingCertainFiles/folder1"
-      ).sorted
+        wd / "unzipAllExceptExcludingCertainFiles/one.txt"
+      )
 
       assert(paths == expected)
     }
@@ -226,22 +222,5 @@ object ZipOpTests extends TestSuite {
       assert(file2Content == "Content of file2")
     }
 
-    test("emptyFolder") - prep { wd =>
-      val zipFileName = "zipCheckEmptyDirectory.zip"
-      val zipFile = os.zip(
-        dest = wd / zipFileName,
-        sources = Seq(
-          wd / "emptyFolder",
-          wd / "File.txt"
-        )
-      )
-
-      val unzippedFolder = os.unzip(
-        source = wd / zipFileName,
-        dest = wd / "unzipped-empty-directory"
-      )
-
-      assert(os.exists(unzippedFolder / "emptyFolder"))
-    }
   }
 }


### PR DESCRIPTION
This reverts commit 90626dfd9f4371c8eb88ff794faefe7a841af90d.
Fixes #349

I've spent some time trying to do a fix forward but I don't have much time on my hand.
Can we revert this in the meantime and @counter2015 can provide another PR for the empty folder issue?