### PR TITLE
Make creating symlinks and hardlinks count as a read operation

### DIFF
--- a/os/src/FileOps.scala
+++ b/os/src/FileOps.scala
@@ -366,7 +366,7 @@ object exists extends Function1[Path, Boolean] {
 object hardlink {
   def apply(link: Path, dest: Path) = {
     checker.value.onWrite(link)
-    checker.value.onWrite(dest)
+    checker.value.onRead(dest)
     Files.createLink(link.wrapped, dest.wrapped)
   }
 }
@@ -377,7 +377,7 @@ object hardlink {
 object symlink {
   def apply(link: Path, dest: FilePath, perms: PermSet = null): Unit = {
     checker.value.onWrite(link)
-    checker.value.onWrite(dest match {
+    checker.value.onRead(dest match {
       case p: RelPath => link / RelPath.up / p
       case p: SubPath => link / RelPath.up / p
       case p: Path => p

--- a/os/test/src/CheckerTests.scala
+++ b/os/test/src/CheckerTests.scala
@@ -278,7 +278,7 @@ object CheckerTests extends TestSuite {
       }
     }
     test("hardlink") - prepChecker { wd =>
-      intercept[WriteDenied] {
+      intercept[ReadDenied] {
         os.hardlink(wd / "Linked.txt", rd / "File.txt")
       }
       os.exists(wd / "Linked.txt") ==> false


### PR DESCRIPTION
Although this might let you launder writes to files through the symlink, that can be something that the `onWrite` callback checks if necessary