### PR TITLE
Fix os.write.outputStream with perms for Scala 3

### DIFF
--- a/os/src/ReadWriteOps.scala
+++ b/os/src/ReadWriteOps.scala
@@ -30,8 +30,8 @@ object write {
     checker.value.onWrite(target)
     if (createFolders) makeDir.all(target / RelPath.up, perms)
     if (perms != null && !exists(target)) {
-      val permArray =
-        if (perms == null) Array[FileAttribute[PosixFilePermission]]()
+      val permArray: Array[FileAttribute[_]] =
+        if (perms == null) Array.empty
         else Array(PosixFilePermissions.asFileAttribute(perms.toSet()))
       java.nio.file.Files.createFile(target.toNIO, permArray: _*)
     }

--- a/os/test/src/ReadingWritingTests.scala
+++ b/os/test/src/ReadingWritingTests.scala
@@ -124,6 +124,19 @@ object ReadingWritingTests extends TestSuite {
           os.read(wd / "New File.txt") ==> "Hello"
         }
       }
+      test("outputStreamWithPerms") {
+        test - prep { wd =>
+          val out = os.write.outputStream(wd / "New File.txt", perms = os.PermSet(420))
+          out.write('H')
+          out.write('e')
+          out.write('l')
+          out.write('l')
+          out.write('o')
+          out.close()
+
+          os.read(wd / "New File.txt") ==> "Hello"
+        }
+      }
     }
     test("truncate") {
       test - prep { wd =>

--- a/os/test/src/ReadingWritingTests.scala
+++ b/os/test/src/ReadingWritingTests.scala
@@ -125,7 +125,7 @@ object ReadingWritingTests extends TestSuite {
         }
       }
       test("outputStreamWithPerms") {
-        test - prep { wd =>
+        test - prep { wd => if (!scala.util.Properties.isWin) {
           val out = os.write.outputStream(wd / "New File.txt", perms = os.PermSet(420))
           out.write('H')
           out.write('e')
@@ -135,7 +135,7 @@ object ReadingWritingTests extends TestSuite {
           out.close()
 
           os.read(wd / "New File.txt") ==> "Hello"
-        }
+        }}
       }
     }
     test("truncate") {

--- a/os/test/src/ReadingWritingTests.scala
+++ b/os/test/src/ReadingWritingTests.scala
@@ -125,17 +125,19 @@ object ReadingWritingTests extends TestSuite {
         }
       }
       test("outputStreamWithPerms") {
-        test - prep { wd => if (!scala.util.Properties.isWin) {
-          val out = os.write.outputStream(wd / "New File.txt", perms = os.PermSet(420))
-          out.write('H')
-          out.write('e')
-          out.write('l')
-          out.write('l')
-          out.write('o')
-          out.close()
+        test - prep { wd =>
+          if (!scala.util.Properties.isWin) {
+            val out = os.write.outputStream(wd / "New File.txt", perms = os.PermSet(420))
+            out.write('H')
+            out.write('e')
+            out.write('l')
+            out.write('l')
+            out.write('o')
+            out.close()
 
-          os.read(wd / "New File.txt") ==> "Hello"
-        }}
+            os.read(wd / "New File.txt") ==> "Hello"
+          }
+        }
       }
     }
     test("truncate") {


### PR DESCRIPTION
On Scala 3

```scala
os.write.outputStream(os.pwd / "text", perms = os.PermSet(420))

java.lang.ClassCastException: class [Ljava.nio.file.attribute.FileAttribute; cannot be cast to class scala.collection.immutable.Seq ([Ljava.nio.file.attribute.FileAttribute; is in module java.base of loader 'bootstrap'; scala.collection.immutable.Seq is in unnamed module of loader java.net.URLClassLoader @4520ebad)
  os.write$.outputStream(ReadWriteOps.scala:35)
  ammonite.$sess.cmd0$.<clinit>(cmd0.sc:1)
```

