### PR TITLE
fix os.copy with mergeFolders=true

### DIFF
--- a/os/src/FileOps.scala
+++ b/os/src/FileOps.scala
@@ -202,7 +202,9 @@ object copy {
 
     def copyOne(p: Path): Unit = {
       val target = to / p.relativeTo(from)
-      if (mergeFolders && isDir(p, followLinks) && isDir(target, followLinks)) {
+      if (mergeFolders && isDir(p, false) && !exists(target, false)) {
+        os.makeDir(target)
+      } else if (mergeFolders && isDir(p, followLinks) && isDir(target, followLinks)) {
         // nothing to do
       } else {
         Files.copy(p.wrapped, target.wrapped, opts1 ++ opts2 ++ opts3: _*)


### PR DESCRIPTION
Bug appears when we call os.copy with mergeFolders = true

if target doesn't contain inner directories corresponding to source os.copy with mergeFolders will fail try to copy source directory as it was a file and fail with FileAlreadyExistsException

createFolders = true doesn't fix things

this is because os.isDir(targetDir) returns false if path doesn't exist

This PR adds explicit target directory creation if sourceDirectory is directory and targetDirectory doesn't exist